### PR TITLE
feat: configure vite and express for replit

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,10 @@
+run = "npm run dev"
+
+[env]
+PORT = "5000"
+
+[[ports]]
+port = 5173
+
+[[ports]]
+port = 5000

--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>ShaderVibe</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,0 +1,25 @@
+import { useState } from 'react'
+
+export default function App() {
+  const [msg, setMsg] = useState<string>('')
+
+  async function ping() {
+    try {
+      const r = await fetch('/api/health')
+      const j = await r.json()
+      setMsg(JSON.stringify(j))
+    } catch (e) {
+      setMsg(String(e))
+    }
+  }
+
+  return (
+    <div style={{ padding: 24, fontFamily: 'system-ui, sans-serif' }}>
+      <h1>Frontend is live (5173)</h1>
+      <button onClick={ping} style={{ padding: 10, border: '1px solid #ccc' }}>
+        Call /api/health
+      </button>
+      <pre>{msg}</pre>
+    </div>
+  )
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react'
+import { createRoot } from 'react-dom/client'
+import App from './App'
+import './index.css'
+
+createRoot(document.getElementById('root')!).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+)

--- a/package.json
+++ b/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "shadervibe",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "concurrently -k \"npm run server\" \"npm run client\"",
+    "server": "tsx server/index.ts",
+    "client": "vite --host 0.0.0.0 --port 5173",
+    "build": "npm run build:client",
+    "build:client": "vite build",
+    "preview": "vite preview --host 0.0.0.0 --port 4173"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "dotenv": "^16.4.5",
+    "express": "^4.19.2",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/express": "^4.17.21",
+    "@types/node": "^20.14.10",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.1",
+    "autoprefixer": "^10.4.20",
+    "concurrently": "^8.2.2",
+    "postcss": "^8.4.41",
+    "tailwindcss": "^3.4.10",
+    "tsx": "^4.16.2",
+    "typescript": "^5.4.5",
+    "vite": "^5.4.2"
+  }
+}

--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+}

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,0 +1,21 @@
+import express from 'express'
+import cors from 'cors'
+import dotenv from 'dotenv'
+
+dotenv.config()
+const app = express()
+app.use(cors())
+app.use(express.json())
+
+app.get('/', (_req, res) => {
+  res.type('text').send('Backend up on 5000. Open port 5173 for the frontend.')
+})
+
+app.get('/api/health', (_req, res) => {
+  res.json({ ok: true, service: 'api', ts: Date.now() })
+})
+
+const PORT = Number(process.env.PORT) || 5000
+app.listen(PORT, '0.0.0.0', () => {
+  console.log(`Server listening on ${PORT}`)
+})

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,5 @@
+export default {
+  content: ['./client/index.html', './client/src/**/*.{ts,tsx}'],
+  theme: { extend: {} },
+  plugins: []
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "strict": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "types": ["node"]
+  },
+  "include": ["server", "client/src", "vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: '0.0.0.0',
+    port: 5173,
+    strictPort: true,
+    allowedHosts: true,
+    proxy: {
+      '/api': { target: 'http://localhost:5000', changeOrigin: true }
+    }
+  }
+})


### PR DESCRIPTION
## Summary
- add Vite React client and Express API with ports 5173 and 5000
- configure Replit run command and port exposure for reliable preview

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run dev` *(fails: concurrently: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adcbda12e4832d88fe19ed61a27387