### PR TITLE
feat: add interactive shader controls

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,25 +1,41 @@
-import { useState } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from "react"
+import "./index.css"
+import Controls from "./components/Controls"
+import type { AppState } from "./types"
+import { defaults, initialState, writeLocal, writeToUrl } from "./lib/state"
 
 export default function App() {
-  const [msg, setMsg] = useState<string>('')
+  const [state, setState] = useState<AppState>(() => initialState())
+  const saveTick = useRef<number | null>(null)
 
-  async function ping() {
-    try {
-      const r = await fetch('/api/health')
-      const j = await r.json()
-      setMsg(JSON.stringify(j))
-    } catch (e) {
-      setMsg(String(e))
-    }
-  }
+  useEffect(() => {
+    if (saveTick.current) cancelAnimationFrame(saveTick.current)
+    saveTick.current = requestAnimationFrame(() => {
+      writeLocal(state)
+      writeToUrl(state, true)
+    })
+  }, [state])
+
+  const gradient = useMemo(() => {
+    const hue = Math.round(state.hue * 360)
+    const a = `hsl(${hue}, 90%, ${Math.max(20, 60 - state.intensity * 20)}%)`
+    const b = `hsl(${(hue + 40) % 360}, 90%, ${Math.min(80, 40 + state.intensity * 20)}%)`
+    return `linear-gradient(90deg, ${a}, ${b})`
+  }, [state])
 
   return (
-    <div style={{ padding: 24, fontFamily: 'system-ui, sans-serif' }}>
-      <h1>Frontend is live (5173)</h1>
-      <button onClick={ping} style={{ padding: 10, border: '1px solid #ccc' }}>
-        Call /api/health
-      </button>
-      <pre>{msg}</pre>
+    <div className="page">
+      <div className="stage" style={{ backgroundImage: gradient, animationDuration: `${Math.max(0.2, 3 - state.speed)}s` }} />
+      <Controls
+        state={state}
+        onChange={(next) => setState((s) => ({ ...s, ...next }))}
+        onReset={() => {
+          setState(defaults)
+          history.replaceState(null, "", location.pathname)
+          localStorage.removeItem("shadervibe:state:v1")
+        }}
+      />
     </div>
   )
 }
+

--- a/client/src/components/Controls.tsx
+++ b/client/src/components/Controls.tsx
@@ -1,0 +1,65 @@
+import React from "react"
+import type { AppState } from "../types"
+
+type Props = {
+  state: AppState
+  onChange: (next: Partial<AppState>) => void
+  onReset: () => void
+}
+
+export default function Controls({ state, onChange, onReset }: Props) {
+  return (
+    <div className="controls">
+      <details open>
+        <summary>Colors</summary>
+        <label className="row">
+          <span>Hue: {state.hue.toFixed(2)}</span>
+          <input
+            type="range"
+            min={0}
+            max={1}
+            step={0.01}
+            value={state.hue}
+            onChange={(e) => onChange({ hue: Number(e.target.value) })}
+          />
+        </label>
+      </details>
+
+      <details open>
+        <summary>Motion</summary>
+        <label className="row">
+          <span>Speed: {state.speed.toFixed(2)}</span>
+          <input
+            type="range"
+            min={0}
+            max={3}
+            step={0.01}
+            value={state.speed}
+            onChange={(e) => onChange({ speed: Number(e.target.value) })}
+          />
+        </label>
+      </details>
+
+      <details open>
+        <summary>FX</summary>
+        <label className="row">
+          <span>Intensity: {state.intensity.toFixed(2)}</span>
+          <input
+            type="range"
+            min={0}
+            max={2}
+            step={0.01}
+            value={state.intensity}
+            onChange={(e) => onChange({ intensity: Number(e.target.value) })}
+          />
+        </label>
+      </details>
+
+      <div className="actions">
+        <button onClick={onReset}>Reset</button>
+        <button onClick={() => navigator.clipboard.writeText(location.href)}>Copy Link</button>
+      </div>
+    </div>
+  )
+}
+

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,3 +1,10 @@
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
+.page{display:grid;grid-template-rows:1fr auto;min-height:100vh;background:#000;color:#fff}
+.stage{height:60vh;margin:16px;border-radius:16px;animation:pan linear infinite;background:#222}
+.controls{padding:16px;background:rgba(0,0,0,.6);backdrop-filter:saturate(140%) blur(6px)}
+.row{display:grid;grid-template-columns:140px 1fr;gap:12px;align-items:center;margin:10px 0}
+.row input[type="range"]{width:100%}
+.actions{display:flex;gap:8px;margin-top:12px}
+.actions button{background:#0b0b0c;color:#fff;border:1px solid #2a2a2e;border-radius:8px;padding:8px 12px;cursor:pointer}
+.actions button:hover{border-color:#3b3b40}
+details summary{cursor:pointer;user-select:none;margin:6px 0}
+@keyframes pan{0%{background-position:0% 50%}100%{background-position:100% 50%}}

--- a/client/src/lib/state.ts
+++ b/client/src/lib/state.ts
@@ -1,0 +1,64 @@
+import type { AppState } from "../types"
+
+const KEY = "shadervibe:state:v1"
+
+export const defaults: AppState = {
+  hue: 0.5,
+  speed: 1,
+  intensity: 1,
+}
+
+export function parseFromUrl(search: string): Partial<AppState> {
+  const p = new URLSearchParams(search)
+  const h = p.get("h")
+  const s = p.get("s")
+  const i = p.get("i")
+  const out: Partial<AppState> = {}
+  if (h !== null && !Number.isNaN(Number(h))) out.hue = clamp01(Number(h))
+  if (s !== null && !Number.isNaN(Number(s))) out.speed = clamp01(Number(s)) * 3
+  if (i !== null && !Number.isNaN(Number(i))) out.intensity = clamp01(Number(i)) * 2
+  return out
+}
+
+export function writeToUrl(state: AppState, replace = true) {
+  const q = new URLSearchParams()
+  q.set("h", round(state.hue, 3).toString())
+  q.set("s", round(state.speed / 3, 3).toString())
+  q.set("i", round(state.intensity / 2, 3).toString())
+  const url = `${location.pathname}?${q.toString()}${location.hash}`
+  if (replace) history.replaceState(null, "", url)
+  else history.pushState(null, "", url)
+}
+
+export function readLocal(): Partial<AppState> {
+  try {
+    const raw = localStorage.getItem(KEY)
+    if (!raw) return {}
+    const parsed = JSON.parse(raw)
+    const out: Partial<AppState> = {}
+    if (typeof parsed.hue === "number") out.hue = clamp01(parsed.hue)
+    if (typeof parsed.speed === "number") out.speed = Math.max(0, parsed.speed)
+    if (typeof parsed.intensity === "number") out.intensity = Math.max(0, parsed.intensity)
+    return out
+  } catch {
+    return {}
+  }
+}
+
+export function writeLocal(state: AppState) {
+  localStorage.setItem(KEY, JSON.stringify(state))
+}
+
+export function initialState(): AppState {
+  return { ...defaults, ...readLocal(), ...parseFromUrl(location.search) }
+}
+
+function clamp01(n: number) {
+  return Math.min(1, Math.max(0, n))
+}
+
+function round(n: number, d: number) {
+  const m = Math.pow(10, d)
+  return Math.round(n * m) / m
+}
+

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -1,0 +1,6 @@
+export interface AppState {
+  hue: number
+  speed: number
+  intensity: number
+}
+


### PR DESCRIPTION
## Summary
- add AppState types and persistent state management
- introduce Controls component for hue, speed, and intensity
- animate gradient stage with configurable settings

## Testing
- `npm run build` *(fails: Could not resolve entry module "index.html")*

------
https://chatgpt.com/codex/tasks/task_e_68add47271e0832dabb5c2e891b1a3a9