### PR TITLE
feat: add persistent reset button

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -8,14 +8,5 @@
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
-    <button id="sv-reset" style="position:fixed;right:16px;bottom:16px;z-index:9999;padding:10px 14px;background:#111;color:#fff;border:1px solid rgba(255,255,255,.35);border-radius:10px;font:600 14px/1 system-ui,-apple-system,Segoe UI,Roboto,sans-serif;box-shadow:0 4px 16px rgba(0,0,0,.35);">
-      Reset
-    </button>
-    <script>
-      document.getElementById('sv-reset').addEventListener('click', function () {
-        ['sv_hue','sv_speed','sv_intensity'].forEach(function(k){ localStorage.removeItem(k); });
-        location.reload();
-      });
-    </script>
   </body>
 </html>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useRef, useState } from "react"
 import "./index.css"
 import Controls from "./components/Controls"
+import ResetButton from "./components/ResetButton"
 import type { AppState } from "./types"
 import { defaults, initialState, writeLocal, writeToUrl } from "./lib/state"
 
@@ -24,18 +25,21 @@ export default function App() {
   }, [state])
 
   return (
-    <div className="page">
-      <div className="stage" style={{ backgroundImage: gradient, animationDuration: `${Math.max(0.2, 3 - state.speed)}s` }} />
-      <Controls
-        state={state}
-        onChange={(next) => setState((s) => ({ ...s, ...next }))}
-        onReset={() => {
-          setState(defaults)
-          history.replaceState(null, "", location.pathname)
-          localStorage.removeItem("shadervibe:state:v1")
-        }}
-      />
-    </div>
+    <>
+      <div className="page">
+        <div className="stage" style={{ backgroundImage: gradient, animationDuration: `${Math.max(0.2, 3 - state.speed)}s` }} />
+        <Controls
+          state={state}
+          onChange={(next) => setState((s) => ({ ...s, ...next }))}
+          onReset={() => {
+            setState(defaults)
+            history.replaceState(null, "", location.pathname)
+            localStorage.removeItem("shadervibe:state:v1")
+          }}
+        />
+      </div>
+      <ResetButton />
+    </>
   )
 }
 

--- a/client/src/components/ResetButton.tsx
+++ b/client/src/components/ResetButton.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+
+const ResetButton: React.FC = () => {
+  const onClick = () => {
+    ["sv_hue", "sv_speed", "sv_intensity"].forEach((k) =>
+      localStorage.removeItem(k)
+    );
+    window.location.reload();
+  };
+
+  const style: React.CSSProperties = {
+    position: "fixed",
+    right: 16,
+    bottom: 16,
+    zIndex: 2147483647,
+    padding: "10px 14px",
+    background: "#111",
+    color: "#fff",
+    border: "1px solid rgba(255,255,255,.35)",
+    borderRadius: 10,
+    fontWeight: 600,
+    fontSize: 14,
+    lineHeight: 1,
+    cursor: "pointer",
+  };
+
+  return (
+    <button style={style} onClick={onClick} aria-label="Reset controls">
+      Reset
+    </button>
+  );
+};
+
+export default ResetButton;
+


### PR DESCRIPTION
## Summary
- add a React `ResetButton` component to clear shader settings from localStorage and reload
- render the reset button in `App` and remove the inline HTML button

## Testing
- `npm test` *(fails: Missing script "test")*
- `cd client && npx vite build`


------
https://chatgpt.com/codex/tasks/task_e_68adde9328b4832da031cf5ba1067e6a