### PR TITLE
feat: add debug overlay and persistent controls panel

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,15 +1,39 @@
-import React from "react";
+import React, { useEffect } from "react";
 import Controls from "./components/Controls";
+import DebugOverlay from "./components/DebugOverlay";
 import "./index.css";
 
 export default function App() {
+  useEffect(() => {
+    console.log(`[App] mounted @ ${new Date().toISOString()}`);
+    const canvas = document.getElementById("shader-canvas");
+    if (canvas) {
+      console.log("[Canvas] ready");
+    }
+  }, []);
+
   return (
     <div className="app">
-      <h1 className="title">Hello from Express API 👋</h1>
+      <h1 style={{ color: "magenta" }}>APP SHELL LOADED</h1>
       <div className="canvas-wrap">
-        <canvas id="shader-canvas"></canvas>
+        <canvas id="shader-canvas" className="shader-canvas"></canvas>
       </div>
-      <Controls />
+      <div
+        style={{
+          position: "fixed",
+          left: 0,
+          right: 0,
+          bottom: 56,
+          padding: "12px 16px",
+          zIndex: 100000,
+          pointerEvents: "auto",
+          background: "rgba(0,0,0,.75)",
+          color: "#fff",
+        }}
+      >
+        <Controls />
+      </div>
+      <DebugOverlay />
     </div>
   );
 }

--- a/client/src/components/Controls.tsx
+++ b/client/src/components/Controls.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { resetControls } from "../lib/resetControls";
 
 const read = (k: string, d: number) => {
   const v = localStorage.getItem(k);
@@ -6,10 +7,15 @@ const read = (k: string, d: number) => {
 };
 const write = (k: string, v: number) => localStorage.setItem(k, String(v));
 
-export default function Controls() {
+function Controls() {
   const [hue, setHue] = useState(read("hue", 0.6));
   const [speed, setSpeed] = useState(read("speed", 1.0));
   const [intensity, setIntensity] = useState(read("intensity", 1.0));
+
+  useEffect(() => {
+    (window as any).__controlsMounted = true;
+    console.log("[Controls] mounted");
+  }, []);
 
   useEffect(() => write("hue", hue), [hue]);
   useEffect(() => write("speed", speed), [speed]);
@@ -19,25 +25,11 @@ export default function Controls() {
     setHue(0.6);
     setSpeed(1.0);
     setIntensity(1.0);
-    localStorage.removeItem("hue");
-    localStorage.removeItem("speed");
-    localStorage.removeItem("intensity");
+    resetControls();
   };
 
   return (
-    <div
-      className="controls-panel"
-      style={{
-        position: "fixed",
-        bottom: 0,
-        left: 0,
-        width: "100%",
-        background: "rgba(0, 0, 0, 0.8)",
-        color: "#fff",
-        padding: "16px",
-        zIndex: 1000,
-      }}
-    >
+    <div className="controls-panel">
       <details>
         <summary>Colors</summary>
         <div className="row">
@@ -83,8 +75,9 @@ export default function Controls() {
         </div>
       </details>
 
-      <div style={{ color: "red" }}>RESET TEST BUTTON</div>
       <button className="reset-btn" onClick={resetAll}>Reset</button>
     </div>
   );
 }
+
+export default Controls;

--- a/client/src/components/DebugOverlay.tsx
+++ b/client/src/components/DebugOverlay.tsx
@@ -1,0 +1,58 @@
+import React, { useEffect, useState } from "react";
+import { resetControls } from "../lib/resetControls";
+
+const buildTimestamp = new Date().toISOString();
+
+export default function DebugOverlay() {
+  const [mounted, setMounted] = useState("unknown");
+
+  useEffect(() => {
+    const update = () => {
+      const v = (window as any).__controlsMounted;
+      setMounted(typeof v === "boolean" ? String(v) : "unknown");
+    };
+    update();
+    const id = setInterval(update, 500);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        left: 0,
+        right: 0,
+        bottom: 0,
+        padding: "12px 16px",
+        fontSize: 14,
+        lineHeight: 1.2,
+        background: "rgba(255, 0, 0, 0.85)",
+        color: "#fff",
+        textShadow: "0 1px 0 rgba(0,0,0,.4)",
+        zIndex: 999999,
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+      }}
+    >
+      <div>
+        DEBUG OVERLAY — Controls mount: {mounted} — Build: {buildTimestamp}
+      </div>
+      <button
+        onClick={resetControls}
+        style={{
+          appearance: "none",
+          border: "1px solid rgba(255,255,255,0.25)",
+          background: "rgba(255,255,255,0.08)",
+          color: "#fff",
+          padding: "8px 14px",
+          borderRadius: 8,
+          fontWeight: 600,
+          cursor: "pointer",
+        }}
+      >
+        Reset
+      </button>
+    </div>
+  );
+}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1,7 +1,13 @@
 :root { color-scheme: dark; }
 * { box-sizing: border-box; }
-html, body, #root { height: 100%; margin: 0; }
-body { background:#000; color:#fff; font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif; }
+html, body, #root { height: 100%; }
+body {
+  margin: 0;
+  overflow-x: hidden;
+  background:#000;
+  color:#fff;
+  font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
+}
 
 .app { min-height: 100%; padding: 16px 16px 88px; }
 .title { margin: 0 0 12px; font-size: 28px; line-height: 1.2; }
@@ -14,13 +20,21 @@ body { background:#000; color:#fff; font-family: system-ui, -apple-system, Segoe
   background: #111;
   border: 2px solid #222;
 }
-#shader-canvas { width: 100%; height: 100%; display: block; }
+.shader-canvas { display:block; width:100%; height:auto; }
 
 .controls-panel details { margin-top: 10px; }
 .controls-panel summary { cursor: pointer; font-size: 18px; }
 .controls-panel .row { padding: 10px 0 4px; }
 .controls-panel label { display: block; margin-bottom: 6px; font-size: 16px; }
 .controls-panel input[type="range"] { width: 100%; }
+
+.ui-layer {
+  z-index: 100000;
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 56px;
+}
 
 .controls-bar {
   position: fixed;

--- a/client/src/lib/resetControls.ts
+++ b/client/src/lib/resetControls.ts
@@ -1,0 +1,8 @@
+export function resetControls() {
+  try {
+    localStorage.removeItem("hue");
+    localStorage.removeItem("speed");
+    localStorage.removeItem("intensity");
+  } catch {}
+  window.location.reload();
+}


### PR DESCRIPTION
## Summary
- add global reset utility for controls
- display controls and debug overlay in fixed bottom layers
- mark controls mount state and expose via debug overlay

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: Could not resolve entry module "index.html".)*

------
https://chatgpt.com/codex/tasks/task_e_68adfd932e9c832d8ef8faf03c69fc4d