### PR TITLE
feat: persistent controls with reset

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width,initial-scale=1" />
-    <meta name="active-client" content="client/index.html" />
+    <meta name="active-client" content="/client/index.html" />
     <title>Shadervibe</title>
   </head>
   <body>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,51 +1,66 @@
-import React, { useEffect } from "react";
-import Controls from "./components/Controls";
-import DebugOverlay from "./components/DebugOverlay";
-import ResetButton from "./components/ResetButton";
-import "./index.css";
+import React from 'react';
+import Controls from './components/Controls';
+import './index.css';
 
 export default function App() {
-  useEffect(() => {
-    console.log("[App] ACTIVE", new Date().toISOString());
+  console.log('[App ACTIVE]', new Date().toISOString());
+
+  const [hue, setHue] = React.useState(0.5);
+  const [speed, setSpeed] = React.useState(1.0);
+  const [intensity, setIntensity] = React.useState(1.0);
+
+  React.useEffect(() => {
+    const H = parseFloat(localStorage.getItem('hue') ?? '');
+    if (!Number.isNaN(H)) setHue(H);
+    const S = parseFloat(localStorage.getItem('speed') ?? '');
+    if (!Number.isNaN(S)) setSpeed(S);
+    const I = parseFloat(localStorage.getItem('intensity') ?? '');
+    if (!Number.isNaN(I)) setIntensity(I);
   }, []);
+  React.useEffect(() => { localStorage.setItem('hue', String(hue)); }, [hue]);
+  React.useEffect(() => { localStorage.setItem('speed', String(speed)); }, [speed]);
+  React.useEffect(() => { localStorage.setItem('intensity', String(intensity)); }, [intensity]);
+
+  const onReset = () => {
+    localStorage.removeItem('hue');
+    localStorage.removeItem('speed');
+    localStorage.removeItem('intensity');
+    window.location.reload();
+  };
 
   return (
     <div className="app">
-      <h1 style={{ color: "magenta" }}>APP SHELL LOADED</h1>
       <div className="canvas-wrap">
-        <canvas id="shader-canvas" className="shader-canvas"></canvas>
+        <canvas
+          id="shader-canvas"
+          className="shader-canvas"
+          style={{ position: 'relative', zIndex: 1 }}
+        ></canvas>
       </div>
+
+      <Controls
+        valueHue={hue} onHue={setHue}
+        valueSpeed={speed} onSpeed={setSpeed}
+        valueIntensity={intensity} onIntensity={setIntensity}
+        onReset={onReset}
+      />
+
       <div
         style={{
-          position: "fixed",
-          left: 0,
-          right: 0,
-          bottom: "56px",
-          padding: "12px 16px",
-          zIndex: 100000,
-          pointerEvents: "auto",
-          background: "rgba(0,0,0,.75)",
-          color: "#fff",
-        }}
-      >
-        <Controls />
-      </div>
-      <ResetButton />
-      <div
-        style={{
-          position: "fixed",
+          position: 'fixed',
           right: 8,
           bottom: 8,
-          zIndex: 999999,
-          background: "#0bf",
-          color: "#000",
-          padding: "6px 8px",
+          zIndex: 2147483647,
+          background: '#0ff',
+          color: '#000',
+          padding: '6px 8px',
           fontSize: 12,
+          borderRadius: 6,
+          boxShadow: '0 0 6px rgba(0,0,0,.4)'
         }}
       >
         ACTIVE CLIENT
       </div>
-      <DebugOverlay />
     </div>
   );
 }

--- a/client/src/components/Controls.tsx
+++ b/client/src/components/Controls.tsx
@@ -1,73 +1,71 @@
-import React, { useEffect, useState } from "react";
+import React, {useEffect, useState} from 'react';
 
-const read = (k: string, d: number) => {
-  const v = localStorage.getItem(k);
-  return v === null ? d : Number(v);
+//
+// /client/src/components/Controls.tsx
+//
+
+type Props = {
+  valueHue: number; onHue:(n:number)=>void;
+  valueSpeed: number; onSpeed:(n:number)=>void;
+  valueIntensity: number; onIntensity:(n:number)=>void;
+  onReset: ()=>void;
 };
-const write = (k: string, v: number) => localStorage.setItem(k, String(v));
 
-function Controls() {
-  const [hue, setHue] = useState(read("hue", 0.6));
-  const [speed, setSpeed] = useState(read("speed", 1.0));
-  const [intensity, setIntensity] = useState(read("intensity", 1.0));
-
-  useEffect(() => {
-    (window as any).__controlsMounted = true;
-    console.log("[Controls] mounted");
-  }, []);
-
-  useEffect(() => write("hue", hue), [hue]);
-  useEffect(() => write("speed", speed), [speed]);
-  useEffect(() => write("intensity", intensity), [intensity]);
-
+export default function Controls(p: Props) {
   return (
-    <div className="controls-panel">
-      <details>
-        <summary>Colors</summary>
-        <div className="row">
-          <label>Hue: {hue.toFixed(2)}</label>
-          <input
-            type="range"
-            min={0}
-            max={1}
-            step={0.01}
-            value={hue}
-            onChange={(e) => setHue(Number(e.target.value))}
-          />
-        </div>
-      </details>
+    <div
+      data-testid="controls"
+      style={{
+        position:'fixed',
+        left:0, right:0, bottom:0,
+        zIndex: 2147483646,
+        background:'rgba(0,0,0,0.65)',
+        backdropFilter:'blur(6px)',
+        WebkitBackdropFilter:'blur(6px)',
+        borderTop:'1px solid rgba(255,255,255,.15)',
+        color:'#fff',
+        padding:'10px 12px',
+        fontFamily:'system-ui, -apple-system, Segoe UI, Roboto, sans-serif'
+      }}
+    >
+      <div style={{display:'grid', gap:10}}>
+        <details open>
+          <summary>Colors</summary>
+          <label>Hue: {p.valueHue.toFixed(2)}</label>
+          <input type="range" min="0" max="1" step="0.01"
+                 value={p.valueHue}
+                 onChange={e=>p.onHue(parseFloat(e.target.value))} />
+        </details>
 
-      <details>
-        <summary>Motion</summary>
-        <div className="row">
-          <label>Speed: {speed.toFixed(2)}</label>
-          <input
-            type="range"
-            min={0}
-            max={3}
-            step={0.01}
-            value={speed}
-            onChange={(e) => setSpeed(Number(e.target.value))}
-          />
-        </div>
-      </details>
+        <details open>
+          <summary>Motion</summary>
+          <label>Speed: {p.valueSpeed.toFixed(2)}</label>
+          <input type="range" min="0" max="3" step="0.01"
+                 value={p.valueSpeed}
+                 onChange={e=>p.onSpeed(parseFloat(e.target.value))} />
+        </details>
 
-      <details>
-        <summary>FX</summary>
-        <div className="row">
-          <label>Intensity: {intensity.toFixed(2)}</label>
-          <input
-            type="range"
-            min={0}
-            max={2}
-            step={0.01}
-            value={intensity}
-            onChange={(e) => setIntensity(Number(e.target.value))}
-          />
-        </div>
-      </details>
+        <details open>
+          <summary>FX</summary>
+          <label>Intensity: {p.valueIntensity.toFixed(2)}</label>
+          <input type="range" min="0" max="3" step="0.01"
+                 value={p.valueIntensity}
+                 onChange={e=>p.onIntensity(parseFloat(e.target.value))} />
+        </details>
+
+        <button
+          data-testid="reset"
+          onClick={p.onReset}
+          style={{
+            marginTop:6, alignSelf:'flex-start',
+            background:'#fff', color:'#000',
+            border:'0', borderRadius:6,
+            padding:'8px 12px', fontWeight:600,
+            cursor:'pointer'
+          }}>
+          Reset
+        </button>
+      </div>
     </div>
   );
 }
-
-export default Controls;


### PR DESCRIPTION
## Summary
- mark client as active in index.html and log when App loads
- add always-visible Controls panel with Reset button
- persist hue/speed/intensity in localStorage and allow clearing via Reset

## Testing
- `npm run dev`


------
https://chatgpt.com/codex/tasks/task_e_68ae0588fa18832da250b7e799856620