### PR TITLE
feat: add debug overlay and fix dev client path

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -1,13 +1,36 @@
 <!doctype html>
-<html>
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width,initial-scale=1" />
-    <meta name="active-client" content="/client/index.html" />
-    <title>Shadervibe</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta name="active-client" content="/client/index.html"/>
+    <title>ShaderVibe</title>
   </head>
   <body>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
+
+    <!-- HARD, UNMISSABLE OVERLAY + RESET -->
+    <div id="__debug_overlay__"
+         style="position:fixed;left:12px;bottom:12px;z-index:2147483647;
+                background:#00ffd0;color:#000;border-radius:10px;
+                box-shadow:0 6px 20px rgba(0,0,0,.35);
+                padding:10px 12px;font:600 13px/1.2 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
+                display:flex;gap:10px;align-items:center">
+      <span>ACTIVE: /client/index.html</span>
+      <button id="__hard_reset__"
+              style="background:#000;color:#fff;border:0;border-radius:8px;padding:8px 10px;cursor:pointer">
+        Reset (clear controls)
+      </button>
+    </div>
+    <script>
+      console.log("[DEBUG] index.html active @", new Date().toISOString());
+      document.getElementById("__hard_reset__")?.addEventListener("click", () => {
+        localStorage.removeItem("hue");
+        localStorage.removeItem("speed");
+        localStorage.removeItem("intensity");
+        location.reload();
+      });
+    </script>
   </body>
 </html>

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "scripts": {
     "dev": "concurrently -k \"npm:server\" \"npm:client\"",
     "server": "tsx server/index.ts",
-    "client": "vite --host 0.0.0.0 --port 5173 --config client/vite.config.ts",
-    "build": "vite build --config client/vite.config.ts",
-    "preview": "vite preview --host 0.0.0.0 --port 5173 --config client/vite.config.ts",
+    "client": "cd client && vite --host 0.0.0.0 --port 5173",
+    "build": "cd client && vite build",
+    "preview": "cd client && vite preview --host 0.0.0.0 --port 5173",
     "clean": "rimraf node_modules client/.vite client/dist dist"
   },
   "dependencies": {


### PR DESCRIPTION
## Summary
- add prominent debug overlay with hard reset to `/client/index.html`
- run Vite from the client directory for dev/build/preview scripts

## Testing
- `npm test` *(fails: Missing script: "test" )*
- `npm run build`
- `pkill -f node || true`
- `npm run dev` *(verified overlay via `curl`)*

------
https://chatgpt.com/codex/tasks/task_e_68ae07df9d98832d9ec1a81503a2ff41