### PR TITLE
Configure dev server path and add index debug tag

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <meta name="active-client" content="/client/index.html"/>
+    <meta name="debug-id" content="client/index.html"/>
     <title>ShaderVibe</title>
   </head>
   <body>

--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "concurrently -k \"npm:server\" \"npm:client\"",
+    "dev": "concurrently -k \"npm run server\" \"cd client && vite --host 0.0.0.0 --port 5173\"",
     "server": "tsx server/index.ts",
-    "client": "cd client && vite --host 0.0.0.0 --port 5173",
+    "client": "vite --host 0.0.0.0 --port 5173",
     "build": "cd client && vite build",
     "preview": "cd client && vite preview --host 0.0.0.0 --port 5173",
     "clean": "rimraf node_modules client/.vite client/dist dist"


### PR DESCRIPTION
## Summary
- mark `client/index.html` with a `debug-id` meta tag to verify the active entrypoint
- update dev scripts so Vite runs from the `client` directory directly

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68ae1535255c832db585511a04ddba46