### PR TITLE
Add entry debug marker and console log

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -7,6 +7,12 @@
     <title>ShaderVibe</title>
   </head>
   <body>
+    <div id="entry-debug" style="position:fixed;top:0;left:0;width:100%;background:#111;color:#0f0;font-size:14px;z-index:9999;padding:4px;text-align:center;">
+      ENTRY DEBUG: This is the active index.html
+    </div>
+    <script>
+      console.log("ENTRY DEBUG: index.html loaded from", window.location.pathname);
+    </script>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
 


### PR DESCRIPTION
## Summary
- display a fixed 'ENTRY DEBUG' banner at the top of the page so the active index.html is obvious
- log the loaded index.html pathname to the console on startup for confirmation

## Testing
- `npm test` *(fails: Missing script "test" in package.json)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ae1a72bce0832d9f9514cca967726b