### PR TITLE
feat: visible entry banner, fixed controls bar + Reset, server debug route

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -3,40 +3,14 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
-    <meta name="debug-id" content="client/index.html"/>
+    <meta name="debug-id" content="client-index-active" />
     <title>ShaderVibe</title>
   </head>
   <body>
-    <div id="entry-debug" style="position:fixed;top:0;left:0;width:100%;background:#111;color:#0f0;font-size:14px;z-index:9999;padding:4px;text-align:center;">
-      ENTRY DEBUG: This is the active index.html
+    <div id="ENTRY_DEBUG" style="position:fixed;top:0;left:0;right:0;z-index:9999;background:#ffeb3b;color:#111;font-weight:700;padding:6px 10px;text-align:center;letter-spacing:.5px;">
+      ENTRY DEBUG • served from: client/index.html
     </div>
-    <script>
-      console.log("ENTRY DEBUG: index.html loaded from", window.location.pathname);
-    </script>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
-
-    <!-- HARD, UNMISSABLE OVERLAY + RESET -->
-    <div id="__debug_overlay__"
-         style="position:fixed;left:12px;bottom:12px;z-index:2147483647;
-                background:#00ffd0;color:#000;border-radius:10px;
-                box-shadow:0 6px 20px rgba(0,0,0,.35);
-                padding:10px 12px;font:600 13px/1.2 system-ui, -apple-system, Segoe UI, Roboto, sans-serif;
-                display:flex;gap:10px;align-items:center">
-      <span>ACTIVE: /client/index.html</span>
-      <button id="__hard_reset__"
-              style="background:#000;color:#fff;border:0;border-radius:8px;padding:8px 10px;cursor:pointer">
-        Reset (clear controls)
-      </button>
-    </div>
-    <script>
-      console.log("[DEBUG] index.html active @", new Date().toISOString());
-      document.getElementById("__hard_reset__")?.addEventListener("click", () => {
-        localStorage.removeItem("hue");
-        localStorage.removeItem("speed");
-        localStorage.removeItem("intensity");
-        location.reload();
-      });
-    </script>
   </body>
 </html>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,64 +3,56 @@ import Controls from './components/Controls';
 import './index.css';
 
 export default function App() {
-  console.log('[App ACTIVE]', new Date().toISOString());
-
-  const [hue, setHue] = React.useState(0.5);
+  const [hue, setHue] = React.useState(0.6);
   const [speed, setSpeed] = React.useState(1.0);
   const [intensity, setIntensity] = React.useState(1.0);
 
   React.useEffect(() => {
-    const H = parseFloat(localStorage.getItem('hue') ?? '');
-    if (!Number.isNaN(H)) setHue(H);
-    const S = parseFloat(localStorage.getItem('speed') ?? '');
-    if (!Number.isNaN(S)) setSpeed(S);
-    const I = parseFloat(localStorage.getItem('intensity') ?? '');
-    if (!Number.isNaN(I)) setIntensity(I);
+    const h = parseFloat(localStorage.getItem('shader:hue') ?? '');
+    if (!Number.isNaN(h)) setHue(h);
+    const s = parseFloat(localStorage.getItem('shader:speed') ?? '');
+    if (!Number.isNaN(s)) setSpeed(s);
+    const i = parseFloat(localStorage.getItem('shader:intensity') ?? '');
+    if (!Number.isNaN(i)) setIntensity(i);
   }, []);
-  React.useEffect(() => { localStorage.setItem('hue', String(hue)); }, [hue]);
-  React.useEffect(() => { localStorage.setItem('speed', String(speed)); }, [speed]);
-  React.useEffect(() => { localStorage.setItem('intensity', String(intensity)); }, [intensity]);
+
+  React.useEffect(() => {
+    localStorage.setItem('shader:hue', String(hue));
+  }, [hue]);
+  React.useEffect(() => {
+    localStorage.setItem('shader:speed', String(speed));
+  }, [speed]);
+  React.useEffect(() => {
+    localStorage.setItem('shader:intensity', String(intensity));
+  }, [intensity]);
+
+  React.useEffect(() => {
+    const canvas = document.getElementById('shader-canvas') as HTMLCanvasElement | null;
+    if (canvas) {
+      canvas.style.backgroundColor = `hsl(${hue * 360},100%,${intensity * 50}%)`;
+    }
+  }, [hue, intensity]);
 
   const onReset = () => {
-    localStorage.removeItem('hue');
-    localStorage.removeItem('speed');
-    localStorage.removeItem('intensity');
-    window.location.reload();
+    localStorage.removeItem('shader:hue');
+    localStorage.removeItem('shader:speed');
+    localStorage.removeItem('shader:intensity');
+    setHue(0.6);
+    setSpeed(1.0);
+    setIntensity(1.0);
   };
 
   return (
     <div className="app">
       <div className="canvas-wrap">
-        <canvas
-          id="shader-canvas"
-          className="shader-canvas"
-          style={{ position: 'relative', zIndex: 1 }}
-        ></canvas>
+        <canvas id="shader-canvas" className="shader-canvas"></canvas>
       </div>
-
       <Controls
-        valueHue={hue} onHue={setHue}
-        valueSpeed={speed} onSpeed={setSpeed}
-        valueIntensity={intensity} onIntensity={setIntensity}
+        hue={hue} onHue={setHue}
+        speed={speed} onSpeed={setSpeed}
+        intensity={intensity} onIntensity={setIntensity}
         onReset={onReset}
       />
-
-      <div
-        style={{
-          position: 'fixed',
-          right: 8,
-          bottom: 8,
-          zIndex: 2147483647,
-          background: '#0ff',
-          color: '#000',
-          padding: '6px 8px',
-          fontSize: 12,
-          borderRadius: 6,
-          boxShadow: '0 0 6px rgba(0,0,0,.4)'
-        }}
-      >
-        ACTIVE CLIENT
-      </div>
     </div>
   );
 }

--- a/client/src/components/Controls.tsx
+++ b/client/src/components/Controls.tsx
@@ -1,70 +1,53 @@
-import React, {useEffect, useState} from 'react';
-
-//
-// /client/src/components/Controls.tsx
-//
+import React from 'react';
 
 type Props = {
-  valueHue: number; onHue:(n:number)=>void;
-  valueSpeed: number; onSpeed:(n:number)=>void;
-  valueIntensity: number; onIntensity:(n:number)=>void;
-  onReset: ()=>void;
+  hue: number;
+  speed: number;
+  intensity: number;
+  onHue: (n: number) => void;
+  onSpeed: (n: number) => void;
+  onIntensity: (n: number) => void;
+  onReset: () => void;
 };
 
-export default function Controls(p: Props) {
+export default function Controls({ hue, speed, intensity, onHue, onSpeed, onIntensity, onReset }: Props) {
   return (
-    <div
-      data-testid="controls"
-      style={{
-        position:'fixed',
-        left:0, right:0, bottom:0,
-        zIndex: 2147483646,
-        background:'rgba(0,0,0,0.65)',
-        backdropFilter:'blur(6px)',
-        WebkitBackdropFilter:'blur(6px)',
-        borderTop:'1px solid rgba(255,255,255,.15)',
-        color:'#fff',
-        padding:'10px 12px',
-        fontFamily:'system-ui, -apple-system, Segoe UI, Roboto, sans-serif'
-      }}
-    >
-      <div style={{display:'grid', gap:10}}>
-        <details open>
-          <summary>Colors</summary>
-          <label>Hue: {p.valueHue.toFixed(2)}</label>
-          <input type="range" min="0" max="1" step="0.01"
-                 value={p.valueHue}
-                 onChange={e=>p.onHue(parseFloat(e.target.value))} />
-        </details>
-
-        <details open>
-          <summary>Motion</summary>
-          <label>Speed: {p.valueSpeed.toFixed(2)}</label>
-          <input type="range" min="0" max="3" step="0.01"
-                 value={p.valueSpeed}
-                 onChange={e=>p.onSpeed(parseFloat(e.target.value))} />
-        </details>
-
-        <details open>
-          <summary>FX</summary>
-          <label>Intensity: {p.valueIntensity.toFixed(2)}</label>
-          <input type="range" min="0" max="3" step="0.01"
-                 value={p.valueIntensity}
-                 onChange={e=>p.onIntensity(parseFloat(e.target.value))} />
-        </details>
-
-        <button
-          data-testid="reset"
-          onClick={p.onReset}
-          style={{
-            marginTop:6, alignSelf:'flex-start',
-            background:'#fff', color:'#000',
-            border:'0', borderRadius:6,
-            padding:'8px 12px', fontWeight:600,
-            cursor:'pointer'
-          }}>
-          Reset
-        </button>
+    <div className="controls-bar">
+      <div className="controls-row">
+        <label>
+          Hue
+          <input
+            type="range"
+            min="0"
+            max="1"
+            step="0.01"
+            value={hue}
+            onChange={(e) => onHue(parseFloat(e.target.value))}
+          />
+        </label>
+        <label>
+          Speed
+          <input
+            type="range"
+            min="0"
+            max="3"
+            step="0.01"
+            value={speed}
+            onChange={(e) => onSpeed(parseFloat(e.target.value))}
+          />
+        </label>
+        <label>
+          Intensity
+          <input
+            type="range"
+            min="0"
+            max="3"
+            step="0.01"
+            value={intensity}
+            onChange={(e) => onIntensity(parseFloat(e.target.value))}
+          />
+        </label>
+        <button className="reset" onClick={onReset}>Reset</button>
       </div>
     </div>
   );

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -21,37 +21,6 @@ body {
 }
 .shader-canvas { display:block; width:100%; height:auto; }
 
-.controls-panel details { margin-top: 10px; }
-.controls-panel summary { cursor: pointer; font-size: 18px; }
-.controls-panel .row { padding: 10px 0 4px; }
-.controls-panel label { display: block; margin-bottom: 6px; font-size: 16px; }
-.controls-panel input[type="range"] { width: 100%; }
-
-.ui-layer {
-  z-index: 100000;
-  position: fixed;
-  left: 0;
-  right: 0;
-  bottom: 56px;
-}
-
-.controls-bar {
-  position: fixed;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  height: 64px;
-  z-index: 1000;
-  backdrop-filter: blur(10px);
-  background: rgba(10,10,10,0.7);
-  border-top: 1px solid rgba(255,255,255,0.12);
-}
-.controls-bar__content {
-  max-width: 980px;
-  margin: 0 auto;
-  height: 100%;
-  padding: 0 16px;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-}
+.controls-bar{position:fixed;left:0;right:0;bottom:0;z-index:1000;background:rgba(0,0,0,.7);backdrop-filter:blur(8px);border-top:1px solid rgba(255,255,255,.15);padding:12px}
+.controls-row{display:flex;gap:16px;align-items:center;flex-wrap:wrap}
+button.reset{border:1px solid #999;padding:6px 10px;border-radius:6px;background:#222;color:#fff}

--- a/client/src/main.tsx
+++ b/client/src/main.tsx
@@ -1,4 +1,7 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
 import App from "./App";
+
+console.log('[ENTRY]', document.querySelector('meta[name="debug-id"]')?.getAttribute('content'));
+
 createRoot(document.getElementById("root")!).render(<App />);

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -9,7 +9,7 @@ export default defineConfig({
     strictPort: true,
     allowedHosts: true,
     proxy: {
-      "/api": { target: "http://localhost:5051", changeOrigin: true }
+      "/api": { target: "http://localhost:5000", changeOrigin: true }
     }
   }
 });

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,10 +1,15 @@
 import express from "express";
 const app = express();
-const PORT = Number(process.env.PORT) || 5051;
+const PORT = Number(process.env.PORT) || 5000;
 
 app.get("/health", (_req, res) => res.json({ ok: true }));
 app.get("/api/hello", (_req, res) => res.json({ message: "Hello from server" }));
 
+app.get("/__debug", (_req, res) => {
+  res.json({ ok: true, server: "express", port: PORT, time: new Date().toISOString() });
+});
+
 app.listen(PORT, "0.0.0.0", () => {
   console.log(`Server listening on ${PORT}`);
+  console.log("SERVER DEBUG route ready");
 });


### PR DESCRIPTION
## Summary
- add debug banner and meta id to entry HTML with console log
- add persistent bottom controls bar with Hue/Speed/Intensity sliders and Reset
- expose Express `/__debug` endpoint logging deployment info

## Testing
- `npm run build`
- `npm test` *(fails: Missing script: "test")*
- `pkill -f node || true && npm run dev` *(server and client started)*
- `curl -s http://localhost:5000/__debug`


------
https://chatgpt.com/codex/tasks/task_e_68ae1cba8df4832db8a6d5789ccadf56