### PR TITLE
feat: add entry debug banner and fixed controls

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -6,6 +6,19 @@
     <title>ShaderVibe</title>
   </head>
   <body>
+    <div id="entry-debug-banner">ENTRY DEBUG: client/index.html :5173</div>
+    <script>
+      console.log("[ENTRY DEBUG] HTML path:", location.pathname);
+      window.__ENTRY_DEBUG__ = "client/index.html";
+    </script>
+    <style>
+      #entry-debug-banner{
+        position:fixed;top:0;left:0;right:0;z-index:2147483647;
+        background:#111;color:#0f0;border-bottom:1px solid #0f0;
+        padding:6px 10px;font:12px/1.2 monospace
+      }
+      body{margin-top:28px}
+    </style>
     <div id="root"></div>
     <script type="module" src="/src/main.tsx"></script>
   </body>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -43,16 +43,18 @@ export default function App() {
   };
 
   return (
-    <div className="app">
+    <div id="app">
       <div className="canvas-wrap">
         <canvas id="shader-canvas" className="shader-canvas"></canvas>
       </div>
-      <Controls
-        hue={hue} onHue={setHue}
-        speed={speed} onSpeed={setSpeed}
-        intensity={intensity} onIntensity={setIntensity}
-        onReset={onReset}
-      />
+      <div id="controls-fixed">
+        <Controls
+          hue={hue} onHue={setHue}
+          speed={speed} onSpeed={setSpeed}
+          intensity={intensity} onIntensity={setIntensity}
+          onReset={onReset}
+        />
+      </div>
     </div>
   );
 }

--- a/client/src/components/Controls.tsx
+++ b/client/src/components/Controls.tsx
@@ -12,7 +12,7 @@ type Props = {
 
 export default function Controls({ hue, speed, intensity, onHue, onSpeed, onIntensity, onReset }: Props) {
   return (
-    <div className="controls-bar">
+    <>
       <div className="controls-row">
         <label>
           Hue
@@ -48,7 +48,7 @@ export default function Controls({ hue, speed, intensity, onHue, onSpeed, onInte
           />
         </label>
       </div>
-      <button className="reset" onClick={onReset}>Reset</button>
-    </div>
+      <button id="reset-btn" className="reset" onClick={onReset}>Reset</button>
+    </>
   );
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -8,7 +8,7 @@ body {
   font-family: system-ui, -apple-system, Segoe UI, Roboto, Helvetica, Arial, sans-serif;
 }
 
-.app { min-height: 100%; padding: 16px 16px 88px; }
+#app { min-height: 100%; padding: 16px 16px 96px; }
 .title { margin: 0 0 12px; font-size: 28px; line-height: 1.2; }
 
 .canvas-wrap {
@@ -21,6 +21,10 @@ body {
 }
 .shader-canvas { display:block; width:100%; height:auto; }
 
-.controls-bar{position:fixed;left:0;right:0;bottom:0;z-index:1000;background:rgba(0,0,0,.7);backdrop-filter:blur(8px);border-top:1px solid rgba(255,255,255,.15);padding:12px;display:flex;flex-direction:column;gap:8px}
+#controls-fixed{
+  position:fixed;left:0;right:0;bottom:0;z-index:2147483000;
+  background:rgba(0,0,0,.65);backdrop-filter:blur(6px);
+  border-top:1px solid rgba(255,255,255,.2);padding:12px
+}
 .controls-row{display:flex;gap:16px;align-items:center;flex-wrap:wrap}
 button.reset{border:1px solid #999;padding:6px 10px;border-radius:6px;background:#222;color:#fff;align-self:flex-start}

--- a/package.json
+++ b/package.json
@@ -4,12 +4,9 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "concurrently -k \"npm run server\" \"npm run client\"",
     "server": "tsx server/index.ts",
     "client": "cd client && vite --host 0.0.0.0 --port 5173",
-    "build": "cd client && vite build",
-    "preview": "cd client && vite preview --host 0.0.0.0 --port 5173",
-    "clean": "rimraf node_modules client/.vite client/dist dist"
+    "dev": "concurrently -k \"npm run server\" \"npm run client\""
   },
   "dependencies": {
     "express": "^4.19.2",


### PR DESCRIPTION
## Summary
- ensure dev scripts only include server, client, and dev
- add entry debug banner to client/index.html for confirming served entry
- make controls bar fixed at bottom with reset button and debugging aids

## Testing
- `npm run dev`
- `curl -s http://localhost:5173/ | head -n 20`
- `node - <<'NODE'
const http=require('http');
http.get('http://localhost:5173/', res=>{ let data=''; res.on('data',d=>data+=d); res.on('end',()=>{ const code=`console.log("[ENTRY DEBUG] HTML path:", location.pathname); window.__ENTRY_DEBUG__ = "client/index.html";`; const vm=require('vm'); const context={location:{pathname:'/'}, window:{}, console}; vm.createContext(context); vm.runInContext(code, context); }); });
NODE`


------
https://chatgpt.com/codex/tasks/task_e_68ae2852ef58832d8cc639262c99da91