### PR TITLE
Add persistent reset control for shader settings

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useMemo, useState } from 'react';
 import './index.css';
+import Controls from './components/Controls';
 
 const STORAGE_KEYS = {
   hue: 'sv_hue',
@@ -18,11 +19,11 @@ function usePersistedNumber(key: string, initial: number) {
 }
 
 export default function App() {
+  console.log('[App] rendering with controls');
   const [hue, setHue] = usePersistedNumber(STORAGE_KEYS.hue, 0.6);
   const [speed, setSpeed] = usePersistedNumber(STORAGE_KEYS.speed, 1.0);
   const [intensity, setIntensity] = usePersistedNumber(STORAGE_KEYS.intensity, 1.0);
-
-  const handleReset = () => {
+  const onReset = () => {
     setHue(0.6);
     setSpeed(1.0);
     setIntensity(1.0);
@@ -42,66 +43,15 @@ export default function App() {
         <canvas id="shader-canvas" className="shader-canvas" />
       </div>
 
-      <div id="controls-fixed">
-        <div className="controls-row">
-          <details open>
-            <summary>Colors</summary>
-            <div className="control">
-              <label htmlFor="hue">Hue: {hue.toFixed(2)}</label>
-              <input
-                id="hue"
-                type="range"
-                min={0}
-                max={1}
-                step={0.01}
-                value={hue}
-                onChange={(e) => setHue(parseFloat(e.target.value))}
-              />
-            </div>
-          </details>
-
-        </div>
-
-        <div className="controls-row">
-          <details open>
-            <summary>Motion</summary>
-            <div className="control">
-              <label htmlFor="speed">Speed: {speed.toFixed(2)}</label>
-              <input
-                id="speed"
-                type="range"
-                min={0}
-                max={5}
-                step={0.01}
-                value={speed}
-                onChange={(e) => setSpeed(parseFloat(e.target.value))}
-              />
-            </div>
-          </details>
-        </div>
-
-        <div className="controls-row">
-          <details open>
-            <summary>FX</summary>
-            <div className="control">
-              <label htmlFor="intensity">Intensity: {intensity.toFixed(2)}</label>
-              <input
-                id="intensity"
-                type="range"
-                min={0}
-                max={2}
-                step={0.01}
-                value={intensity}
-                onChange={(e) => setIntensity(parseFloat(e.target.value))}
-              />
-            </div>
-          </details>
-        </div>
-
-        <div className="controls-actions">
-          <button type="button" className="reset-btn" onClick={handleReset}>Reset</button>
-        </div>
-      </div>
+      <Controls
+        hue={hue}
+        speed={speed}
+        intensity={intensity}
+        setHue={setHue}
+        setSpeed={setSpeed}
+        setIntensity={setIntensity}
+        onReset={onReset}
+      />
     </div>
   );
 }

--- a/client/src/components/Controls.tsx
+++ b/client/src/components/Controls.tsx
@@ -1,54 +1,96 @@
 import React from 'react';
 
-type Props = {
+interface ControlsProps {
   hue: number;
   speed: number;
   intensity: number;
-  onHue: (n: number) => void;
-  onSpeed: (n: number) => void;
-  onIntensity: (n: number) => void;
-  onReset: () => void;
-};
+  setHue?: (n: number) => void;
+  setSpeed?: (n: number) => void;
+  setIntensity?: (n: number) => void;
+  onReset?: () => void;
+}
 
-export default function Controls({ hue, speed, intensity, onHue, onSpeed, onIntensity, onReset }: Props) {
+export default function Controls(props: ControlsProps) {
+  console.log('[Controls] mounted');
+
+  const { hue, speed, intensity, setHue, setSpeed, setIntensity } = props;
+
   return (
-    <>
+    <div id="controls-fixed">
       <div className="controls-row">
-        <label>
-          Hue
-          <input
-            type="range"
-            min="0"
-            max="1"
-            step="0.01"
-            value={hue}
-            onChange={(e) => onHue(parseFloat(e.target.value))}
-          />
-        </label>
-        <label>
-          Speed
-          <input
-            type="range"
-            min="0"
-            max="3"
-            step="0.01"
-            value={speed}
-            onChange={(e) => onSpeed(parseFloat(e.target.value))}
-          />
-        </label>
-        <label>
-          Intensity
-          <input
-            type="range"
-            min="0"
-            max="3"
-            step="0.01"
-            value={intensity}
-            onChange={(e) => onIntensity(parseFloat(e.target.value))}
-          />
-        </label>
+        <details open>
+          <summary>Colors</summary>
+          <div className="control">
+            <label htmlFor="hue">Hue: {hue.toFixed(2)}</label>
+            <input
+              id="hue"
+              type="range"
+              min={0}
+              max={1}
+              step={0.01}
+              value={hue}
+              onChange={(e) => setHue?.(parseFloat(e.target.value))}
+            />
+          </div>
+        </details>
       </div>
-      <button id="reset-btn" className="reset" onClick={onReset}>Reset</button>
-    </>
+
+      <div className="controls-row">
+        <details open>
+          <summary>Motion</summary>
+          <div className="control">
+            <label htmlFor="speed">Speed: {speed.toFixed(2)}</label>
+            <input
+              id="speed"
+              type="range"
+              min={0}
+              max={5}
+              step={0.01}
+              value={speed}
+              onChange={(e) => setSpeed?.(parseFloat(e.target.value))}
+            />
+          </div>
+        </details>
+      </div>
+
+      <div className="controls-row">
+        <details open>
+          <summary>FX</summary>
+          <div className="control">
+            <label htmlFor="intensity">Intensity: {intensity.toFixed(2)}</label>
+            <input
+              id="intensity"
+              type="range"
+              min={0}
+              max={2}
+              step={0.01}
+              value={intensity}
+              onChange={(e) => setIntensity?.(parseFloat(e.target.value))}
+            />
+          </div>
+        </details>
+      </div>
+
+      <div className="controls-actions">
+        <button
+          type="button"
+          className="reset-btn"
+          onClick={() => {
+            if (typeof props?.onReset === 'function') {
+              props.onReset();
+              return;
+            }
+            try {
+              localStorage.removeItem('sv_hue');
+              localStorage.removeItem('sv_speed');
+              localStorage.removeItem('sv_intensity');
+              window.dispatchEvent(new CustomEvent('shadervibe:reset'));
+            } catch {}
+          }}
+        >
+          Reset
+        </button>
+      </div>
+    </div>
   );
 }

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -87,3 +87,6 @@ button.reset{border:1px solid #999;padding:6px 10px;border-radius:6px;background
   cursor: pointer;
 }
 .reset-btn:hover { opacity: 0.9; }
+.controls-actions{ display:flex; justify-content:flex-end; margin-top:8px; }
+.reset-btn{ background:#fff; color:#000; border:none; padding:8px 12px; border-radius:6px; font-weight:600; cursor:pointer; }
+.reset-btn:hover{ opacity:.9; }


### PR DESCRIPTION
## Summary
- render Controls component with Colors/Motion/FX sliders and a persistent Reset button
- wire App to pass values, setters and onReset, and log render events
- style controls actions and reset button

## Testing
- `pkill -f node || true`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68ae33ffe8f4832d9d87cc2551d15771