### PR TITLE
Add reset control for sliders with styling

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -30,6 +30,7 @@ export default function App() {
     localStorage.removeItem(STORAGE_KEYS.hue);
     localStorage.removeItem(STORAGE_KEYS.speed);
     localStorage.removeItem(STORAGE_KEYS.intensity);
+    window.dispatchEvent(new CustomEvent('shadervibe:reset'));
   };
 
   // Expose values to your shader/canvas if needed

--- a/client/src/components/Controls.tsx
+++ b/client/src/components/Controls.tsx
@@ -11,7 +11,7 @@ interface ControlsProps {
 }
 
 export default function Controls(props: ControlsProps) {
-  console.log('[Controls] mounted');
+  console.log('[Controls] (ACTIVE) rendering reset below sliders');
 
   const { hue, speed, intensity, setHue, setSpeed, setIntensity } = props;
 
@@ -81,9 +81,14 @@ export default function Controls(props: ControlsProps) {
               return;
             }
             try {
+              if (typeof setHue === 'function') setHue(0.6);
+              if (typeof setSpeed === 'function') setSpeed(1.0);
+              if (typeof setIntensity === 'function') setIntensity(1.0);
+
               localStorage.removeItem('sv_hue');
               localStorage.removeItem('sv_speed');
               localStorage.removeItem('sv_intensity');
+
               window.dispatchEvent(new CustomEvent('shadervibe:reset'));
             } catch {}
           }}

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -21,13 +21,6 @@ body {
 }
 .shader-canvas { display:block; width:100%; height:auto; }
 
-#controls-fixed{
-  position:fixed;left:0;right:0;bottom:0;z-index:2147483000;
-  background:rgba(0,0,0,.65);backdrop-filter:blur(6px);
-  border-top:1px solid rgba(255,255,255,.2);padding:12px
-}
-.controls-row{display:flex;gap:16px;align-items:center;flex-wrap:wrap}
-button.reset{border:1px solid #999;padding:6px 10px;border-radius:6px;background:#222;color:#fff;align-self:flex-start}
 
 .app-root {
   min-height: 100vh;
@@ -40,53 +33,27 @@ button.reset{border:1px solid #999;padding:6px 10px;border-radius:6px;background
   padding-bottom: 140px; /* space for fixed controls */
 }
 
-#controls-fixed {
-  position: fixed;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  z-index: 1000;
-  background: rgba(0, 0, 0, 0.75);
-  backdrop-filter: blur(8px);
-  border-top: 1px solid rgba(255,255,255,0.15);
-  padding: 12px 16px 16px;
-}
+.controls-row{display:flex;gap:16px;align-items:center;flex-wrap:wrap;margin-bottom:8px;}
 
-.controls-row {
-  margin-bottom: 8px;
-}
+.control{display:flex;flex-direction:column;gap:6px;padding:6px 0;}
 
-.control {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  padding: 6px 0;
-}
+#controls-fixed label{font-size:14px;}
 
-#controls-fixed label {
-  font-size: 14px;
-}
+#controls-fixed input[type="range"]{width:100%;}
 
-#controls-fixed input[type="range"] {
-  width: 100%;
-}
+.controls-actions{display:flex;justify-content:flex-end;margin:8px 0 0}
+.reset-btn{background:#fff;color:#000;border:none;padding:8px 12px;border-radius:6px;font-weight:600;cursor:pointer}
+.reset-btn:hover{opacity:.9}
+/* keep controls above the canvas if needed */
+#controls-fixed,.controls-root{z-index:1000;position:relative}
 
-.controls-actions {
-  display: flex;
-  justify-content: flex-end;
-  margin-top: 6px;
+#controls-fixed{
+  position:fixed;
+  left:0;
+  right:0;
+  bottom:0;
+  background:rgba(0, 0, 0, 0.75);
+  backdrop-filter:blur(8px);
+  border-top:1px solid rgba(255,255,255,0.15);
+  padding:12px 16px 16px;
 }
-
-.reset-btn {
-  background: #ffffff;
-  color: #000000;
-  border: none;
-  padding: 8px 12px;
-  border-radius: 6px;
-  font-weight: 600;
-  cursor: pointer;
-}
-.reset-btn:hover { opacity: 0.9; }
-.controls-actions{ display:flex; justify-content:flex-end; margin-top:8px; }
-.reset-btn{ background:#fff; color:#000; border:none; padding:8px 12px; border-radius:6px; font-weight:600; cursor:pointer; }
-.reset-btn:hover{ opacity:.9; }


### PR DESCRIPTION
## Summary
- Add reset button beneath controls that restores defaults and clears storage
- Expose onReset handler and log activation of controls
- Style reset button and control actions; ensure controls stay above canvas

## Testing
- `npm run client`

------
https://chatgpt.com/codex/tasks/task_e_68ae621d2b54832da34f6d39d88b37d5