### PR TITLE
feat: add ambient background shader

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,27 +1,27 @@
 import React, { useRef } from 'react';
 import './index.css';
 import Controls from './components/Controls';
+import AmbientBackground from './components/AmbientBackground';
 
 export default function App() {
   const controlsRef = useRef({ hue: 0.6, speed: 1.0, intensity: 0.8 });
 
   return (
-    <div className="app">
-      <header className="header">
-        <div className="panel">
-          <h1 style={{ margin: 0 }}>ShaderVibe ✨</h1>
-          {/* Remove any “Live WebGL Parameter Control” subtitle here */}
-        </div>
+    <>
+      <AmbientBackground />
+      <header className="site-header">
+        <h1 className="logo">ShaderVibe ✨</h1>
       </header>
+      <div className="app">
+        <section className="stage">
+          {/* KEEP your existing canvas & GL init EXACTLY as is */}
+          <canvas id="gl-canvas" style={{ width: '100%', height: '100%' }} />
+        </section>
 
-      <section className="stage">
-        {/* KEEP your existing canvas & GL init EXACTLY as is */}
-        <canvas id="gl-canvas" style={{ width: '100%', height: '100%' }} />
-      </section>
-
-      <section className="controls">
-        <Controls controlsRef={controlsRef} />
-      </section>
-    </div>
+        <section className="controls">
+          <Controls controlsRef={controlsRef} />
+        </section>
+      </div>
+    </>
   );
 }

--- a/src/components/AmbientBackground.tsx
+++ b/src/components/AmbientBackground.tsx
@@ -1,0 +1,142 @@
+import React, { useEffect, useRef } from "react";
+
+const VERT = `
+attribute vec2 position;
+void main() {
+  gl_Position = vec4(position, 0.0, 1.0);
+}
+`;
+
+// Three tiny, cheap fragments to choose from.
+// Keep them simple for mobile GPUs.
+const FRAGS = [
+  // Soft plasma
+  `
+  precision mediump float;
+  uniform float uTime, uRatio;
+  vec2 hash22(vec2 p){ p = vec2(dot(p,vec2(127.1,311.7)), dot(p,vec2(269.5,183.3)));
+    return -1.0 + 2.0*fract(sin(p)*43758.5453123); }
+  float noise(vec2 p){
+    vec2 i = floor(p), f = fract(p);
+    vec2 u = f*f*(3.0-2.0*f);
+    return mix( mix(dot(hash22(i+vec2(0,0)), f-vec2(0,0)),
+                    dot(hash22(i+vec2(1,0)), f-vec2(1,0)), u.x),
+                mix(dot(hash22(i+vec2(0,1)), f-vec2(0,1)),
+                    dot(hash22(i+vec2(1,1)), f-vec2(1,1)), u.x), u.y );
+  }
+  void main() {
+    vec2 uv = (gl_FragCoord.xy / vec2(min(uRatio,1.0),1.0)) / 720.0;
+    uv.x *= uRatio;
+    float t = uTime*0.08;
+    float n = noise(uv*6.0 + vec2(t, -t*0.7));
+    float v = 0.5 + 0.5*sin(6.2831*(n*0.6 + t));
+    vec3 col = mix(vec3(0.05,0.0,0.2), vec3(0.0,0.4,0.9), v);
+    gl_FragColor = vec4(col, 0.22); // low alpha for subtle overlay
+  }
+  `,
+  // Radial waves
+  `
+  precision mediump float;
+  uniform float uTime, uRatio;
+  void main(){
+    vec2 uv = gl_FragCoord.xy / 720.0;
+    uv.x *= uRatio;
+    vec2 c = uv - vec2(0.75*uRatio,0.5);
+    float d = length(c);
+    float v = 0.5+0.5*sin(12.0*d - uTime*0.9);
+    vec3 col = mix(vec3(0.02,0.0,0.12), vec3(0.1,0.5,1.0), v);
+    gl_FragColor = vec4(col, 0.18);
+  }
+  `,
+  // Aurora sweep
+  `
+  precision mediump float;
+  uniform float uTime, uRatio;
+  float band(float x, float s, float w){ return smoothstep(s-w,s,x)*smoothstep(s+w,s,x); }
+  void main(){
+    vec2 uv = gl_FragCoord.xy/720.0; uv.x*=uRatio;
+    float t = uTime*0.35;
+    float a = band(uv.y, 0.55+0.15*sin(t*0.9)+0.25*sin(uv.x*5.0+t), 0.15);
+    vec3 col = mix(vec3(0.02,0.02,0.08), vec3(0.2,0.9,0.6), a);
+    gl_FragColor = vec4(col, 0.20);
+  }
+  `
+];
+
+export default function AmbientBackground(){
+  const ref = useRef<HTMLCanvasElement|null>(null);
+  const stopRef = useRef<() => void>(()=>{});
+  useEffect(() => {
+    const canvas = ref.current!;
+    const gl = canvas.getContext("webgl", { premultipliedAlpha: true, alpha: true, antialias: false });
+    if (!gl) return;
+
+    // Pick a fragment at random
+    const FRAG = FRAGS[(Math.random()*FRAGS.length)|0];
+
+    // Compile helpers
+    const sh = (type:number, src:string) => {
+      const s = gl.createShader(type)!; gl.shaderSource(s, src); gl.compileShader(s);
+      return s;
+    };
+    const prog = gl.createProgram()!;
+    gl.attachShader(prog, sh(gl.VERTEX_SHADER, VERT));
+    gl.attachShader(prog, sh(gl.FRAGMENT_SHADER, FRAG));
+    gl.linkProgram(prog); gl.useProgram(prog);
+
+    // Quad
+    const buf = gl.createBuffer()!;
+    gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+    gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([
+      -1,-1,  1,-1, -1,1,  -1,1, 1,-1, 1,1
+    ]), gl.STATIC_DRAW);
+    const loc = gl.getAttribLocation(prog, "position");
+    gl.enableVertexAttribArray(loc);
+    gl.vertexAttribPointer(loc, 2, gl.FLOAT, false, 0, 0);
+
+    // Uniforms
+    const uTime = gl.getUniformLocation(prog, "uTime");
+    const uRatio = gl.getUniformLocation(prog, "uRatio");
+
+    let raf = 0, start = performance.now();
+    const fit = () => {
+      const dpr = Math.min(2, window.devicePixelRatio || 1);
+      const w = window.innerWidth, h = window.innerHeight;
+      canvas.width = w*dpr; canvas.height = h*dpr;
+      canvas.style.width = w+"px"; canvas.style.height = h+"px";
+      gl.viewport(0,0,canvas.width,canvas.height);
+      gl.uniform1f(uRatio, canvas.width/canvas.height);
+    };
+    fit();
+    window.addEventListener("resize", fit);
+
+    // Throttle a bit (approx ~45fps max)
+    let last = 0;
+    const loop = (t:number) => {
+      raf = requestAnimationFrame(loop);
+      if (t - last < 1000/45) return;
+      last = t;
+      const secs = (performance.now()-start)/1000;
+      gl.uniform1f(uTime, secs);
+      gl.drawArrays(gl.TRIANGLES, 0, 6);
+    };
+
+    // Pause when tab hidden
+    const onVis = () => {
+      if (document.hidden) cancelAnimationFrame(raf);
+      else { last = 0; raf = requestAnimationFrame(loop); }
+    };
+    document.addEventListener("visibilitychange", onVis);
+
+    raf = requestAnimationFrame(loop);
+    stopRef.current = () => {
+      cancelAnimationFrame(raf);
+      document.removeEventListener("visibilitychange", onVis);
+      window.removeEventListener("resize", fit);
+      gl.deleteBuffer(buf); gl.deleteProgram(prog);
+    };
+    return () => stopRef.current();
+  }, []);
+
+  return <canvas ref={ref} className="ambient-bg" aria-hidden="true" />;
+}

--- a/src/index.css
+++ b/src/index.css
@@ -124,3 +124,39 @@ input[type="range"]{width:100%;touch-action:none}
 /* Buttons reuse */
 .tab-btn:hover{filter:brightness(0.98)}
 
+
+/* Ambient background canvas behind the app */
+.ambient-bg{
+  position: fixed;
+  inset: 0;
+  z-index: 0;              /* behind content */
+  pointer-events: none;
+  opacity: 1;              /* alpha controlled in shader */
+}
+
+/* Put the rest of the app above */
+#root, .page, .layout, .site-header, .controls-card, .stage, .preview-sticky {
+  position: relative;
+  z-index: 1;
+}
+
+/* Stylized header (no big banner block) */
+.site-header{
+  padding: 16px 16px 8px;
+}
+.logo{
+  font-size: clamp(22px, 5vw, 36px);
+  font-weight: 800;
+  letter-spacing: 0.4px;
+  margin: 0 0 8px 0;
+  background: linear-gradient(90deg,#aab4ff,#ffd1ff,#9bd1ff);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  text-shadow: 0 2px 18px rgba(160,190,255,0.25);
+}
+
+/* Optional: tighten content max width if you have a container class */
+.page, .layout{ max-width: 1200px; margin: 0 auto; }
+
+/* Keep existing tab/controls styles from previous step */


### PR DESCRIPTION
## Summary
- add standalone AmbientBackground shader canvas
- replace banner with stylized header and logo
- layer background behind app with new styles

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68af81ec111c832d91167ece9e028830