### PR TITLE
Add interactive WebGL lab with shader engine

### DIFF
--- a/client/src/glsl.d.ts
+++ b/client/src/glsl.d.ts
@@ -1,0 +1,4 @@
+declare module '*.frag?raw' {
+  const src: string;
+  export default src;
+}

--- a/src/shaders/lab.frag
+++ b/src/shaders/lab.frag
@@ -1,0 +1,43 @@
+precision mediump float;
+
+uniform float uTime;
+uniform vec2  uResolution;
+uniform float uMaster;
+uniform float uEmblem;
+uniform float uCompanion;
+uniform float uTrail;
+uniform float uBackground;
+uniform vec3  uThemeA;
+uniform vec3  uThemeB;
+
+void main() {
+    vec2 uv = gl_FragCoord.xy / uResolution;
+    vec2 p = uv * 2.0 - 1.0;
+    p.x *= uResolution.x / uResolution.y;
+    float t = uTime;
+
+    // background gradient with vignette
+    vec3 base = mix(uThemeB, uThemeA, uv.y);
+    float vign = smoothstep(1.3, 0.7, length(p));
+    vec3 col = base * vign * uBackground;
+
+    // emblem glow at center
+    float em = exp(-3.0 * length(p));
+    col += uThemeA * em * uEmblem;
+
+    // companion orbiting dot
+    vec2 orbit = vec2(cos(t), sin(t)) * 0.5;
+    float comp = exp(-60.0 * dot(p - orbit, p - orbit));
+    col += uThemeA.yzx * comp * uCompanion;
+
+    // trailing ripple / streak
+    vec2 tr = p - orbit;
+    float trail = exp(-4.0 * abs(tr.y)) * exp(-2.0 * max(0.0, tr.x));
+    trail *= 0.5 + 0.5 * sin(10.0 * (tr.x - t));
+    col += uThemeA * 0.6 * trail * uTrail;
+
+    // master multiplier
+    col *= 0.8 + 0.4 * uMaster;
+
+    gl_FragColor = vec4(col, 1.0);
+}

--- a/src/webgl/labEngine.ts
+++ b/src/webgl/labEngine.ts
@@ -1,0 +1,106 @@
+import type React from 'react';
+import fragSource from '../shaders/lab.frag?raw';
+
+export type Uniforms = {
+  master: number;
+  emblem: number;
+  companion: number;
+  trail: number;
+  background: number;
+  themeA: [number, number, number];
+  themeB: [number, number, number];
+};
+
+export function createLabEngine(canvas: HTMLCanvasElement, uniformsRef: React.MutableRefObject<Uniforms>) {
+  const gl = canvas.getContext('webgl');
+  if (!gl) {
+    return { dispose() {} };
+  }
+
+  const vertSrc = `
+    attribute vec2 position;
+    void main(){
+      gl_Position = vec4(position,0.0,1.0);
+    }
+  `;
+
+  const compile = (type: number, src: string): WebGLShader => {
+    const sh = gl.createShader(type)!;
+    gl.shaderSource(sh, src);
+    gl.compileShader(sh);
+    return sh;
+  };
+
+  const vert = compile(gl.VERTEX_SHADER, vertSrc);
+  const frag = compile(gl.FRAGMENT_SHADER, fragSource);
+  const prog = gl.createProgram()!;
+  gl.attachShader(prog, vert);
+  gl.attachShader(prog, frag);
+  gl.linkProgram(prog);
+  gl.useProgram(prog);
+
+  const buf = gl.createBuffer()!;
+  gl.bindBuffer(gl.ARRAY_BUFFER, buf);
+  gl.bufferData(
+    gl.ARRAY_BUFFER,
+    new Float32Array([
+      -1, -1,
+       3, -1,
+      -1,  3,
+    ]),
+    gl.STATIC_DRAW
+  );
+  const loc = gl.getAttribLocation(prog, 'position');
+  gl.enableVertexAttribArray(loc);
+  gl.vertexAttribPointer(loc, 2, gl.FLOAT, false, 0, 0);
+
+  const uTime = gl.getUniformLocation(prog, 'uTime');
+  const uResolution = gl.getUniformLocation(prog, 'uResolution');
+  const uMaster = gl.getUniformLocation(prog, 'uMaster');
+  const uEmblem = gl.getUniformLocation(prog, 'uEmblem');
+  const uCompanion = gl.getUniformLocation(prog, 'uCompanion');
+  const uTrail = gl.getUniformLocation(prog, 'uTrail');
+  const uBackground = gl.getUniformLocation(prog, 'uBackground');
+  const uThemeA = gl.getUniformLocation(prog, 'uThemeA');
+  const uThemeB = gl.getUniformLocation(prog, 'uThemeB');
+
+  const fit = () => {
+    const dpr = Math.min(2, window.devicePixelRatio || 1);
+    const rect = canvas.getBoundingClientRect();
+    canvas.width = rect.width * dpr;
+    canvas.height = rect.height * dpr;
+    gl.viewport(0, 0, canvas.width, canvas.height);
+  };
+  fit();
+  window.addEventListener('resize', fit);
+
+  let raf = 0;
+  const start = performance.now();
+  const frame = () => {
+    raf = requestAnimationFrame(frame);
+    const t = (performance.now() - start) / 1000;
+    gl.uniform1f(uTime, t);
+    gl.uniform2f(uResolution, canvas.width, canvas.height);
+    const u = uniformsRef.current;
+    gl.uniform1f(uMaster, u.master);
+    gl.uniform1f(uEmblem, u.emblem);
+    gl.uniform1f(uCompanion, u.companion);
+    gl.uniform1f(uTrail, u.trail);
+    gl.uniform1f(uBackground, u.background);
+    gl.uniform3fv(uThemeA, u.themeA);
+    gl.uniform3fv(uThemeB, u.themeB);
+    gl.drawArrays(gl.TRIANGLES, 0, 3);
+  };
+  frame();
+
+  return {
+    dispose() {
+      cancelAnimationFrame(raf);
+      window.removeEventListener('resize', fit);
+      gl.deleteBuffer(buf);
+      gl.deleteShader(vert);
+      gl.deleteShader(frag);
+      gl.deleteProgram(prog);
+    }
+  };
+}


### PR DESCRIPTION
## Summary
- Integrate a WebGL lab engine that compiles `lab.frag` and updates uniforms every frame without reinitializing
- Implement GLSL shader with emblem, companion, trail, and background layers plus theme colors
- Refactor Lab Tool page with master/layer sliders, theme presets, and debounced localStorage persistence

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68af9140bc60832d91ea011da8ee221f