### PR TITLE
Wire lab sliders to WebGL

### DIFF
--- a/src/lab/LabTool.tsx
+++ b/src/lab/LabTool.tsx
@@ -1,102 +1,96 @@
-import React, { useState, useEffect, useMemo, useRef, createContext, useContext } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import Tabs, { TabKey } from './Tabs';
+import { createLabEngine, Uniforms } from '../webgl/labEngine';
 import '../index.css';
 
-// Self-audit:
-// - Lab page with master + per-layer sliders and tabs (src/lab/LabTool.tsx)
-// - useLabUniforms hook exporting base/eff values (src/lab/LabTool.tsx lines ~60-78)
-// - Router import updated (src/App.tsx)
-// - Styles for .lab-* appended (src/index.css)
-
-export type LabValues = { master: number; emblem: number; companion: number; trail: number; background: number };
-
-const DEFAULT_VALUES: LabValues = { master: 0.5, emblem: 0.5, companion: 0.5, trail: 0.5, background: 0.5 };
-
-const STORAGE_KEYS: Record<keyof LabValues, string> = {
-  master: 'lab:master',
-  emblem: 'lab:emblem',
-  companion: 'lab:companion',
-  trail: 'lab:trail',
-  background: 'lab:background'
-};
-
-interface LabContextShape { base: LabValues; eff: LabValues; }
-const LabContext = createContext<LabContextShape>({ base: DEFAULT_VALUES, eff: DEFAULT_VALUES });
-
-export function useLabUniforms() { return useContext(LabContext); }
+const ls = (k: string, fallback: number) => Number(localStorage.getItem(k) ?? fallback);
 
 export default function LabTool() {
-  const [master, setMaster] = useState<number>(() => Number(localStorage.getItem(STORAGE_KEYS.master) ?? DEFAULT_VALUES.master));
-  const [emblem, setEmblem] = useState<number>(() => Number(localStorage.getItem(STORAGE_KEYS.emblem) ?? DEFAULT_VALUES.emblem));
-  const [companion, setCompanion] = useState<number>(() => Number(localStorage.getItem(STORAGE_KEYS.companion) ?? DEFAULT_VALUES.companion));
-  const [trail, setTrail] = useState<number>(() => Number(localStorage.getItem(STORAGE_KEYS.trail) ?? DEFAULT_VALUES.trail));
-  const [background, setBackground] = useState<number>(() => Number(localStorage.getItem(STORAGE_KEYS.background) ?? DEFAULT_VALUES.background));
-  const [active, setActive] = useState<TabKey>('emblem');
+  const [master, setMaster] = useState(ls('lab:master', 0.6));
+  const [emblem, setEmblem] = useState(ls('lab:emblem', 0.7));
+  const [companion, setCompanion] = useState(ls('lab:companion', 0.5));
+  const [trail, setTrail] = useState(ls('lab:trail', 0.6));
+  const [background, setBackground] = useState(ls('lab:background', 0.4));
+  const uniformsRef = useRef<Uniforms>({
+    master,
+    emblem,
+    companion,
+    trail,
+    background,
+    themeA: [0.2, 0.6, 1.0],
+    themeB: [0.0, 0.0, 0.0],
+  });
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
 
-  const cardRef = useRef<HTMLDivElement | null>(null);
+  useEffect(() => { const t=setTimeout(()=>localStorage.setItem('lab:master', String(master)),150); return()=>clearTimeout(t); }, [master]);
+  useEffect(() => { const t=setTimeout(()=>localStorage.setItem('lab:emblem', String(emblem)),150); return()=>clearTimeout(t); }, [emblem]);
+  useEffect(() => { const t=setTimeout(()=>localStorage.setItem('lab:companion', String(companion)),150); return()=>clearTimeout(t); }, [companion]);
+  useEffect(() => { const t=setTimeout(()=>localStorage.setItem('lab:trail', String(trail)),150); return()=>clearTimeout(t); }, [trail]);
+  useEffect(() => { const t=setTimeout(()=>localStorage.setItem('lab:background', String(background)),150); return()=>clearTimeout(t); }, [background]);
+
+  useEffect(() => {
+    uniformsRef.current.master = master;
+    uniformsRef.current.emblem = emblem;
+    uniformsRef.current.companion = companion;
+    uniformsRef.current.trail = trail;
+    uniformsRef.current.background = background;
+  }, [master, emblem, companion, trail, background]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const engine = createLabEngine(canvas, uniformsRef);
+    return () => engine.dispose();
+  }, []);
+
+  const [active, setActive] = useState<TabKey>('emblem');
   const num = (e: React.ChangeEvent<HTMLInputElement>) => e.currentTarget.valueAsNumber;
 
-  const base = useMemo<LabValues>(() => ({ master, emblem, companion, trail, background }), [master, emblem, companion, trail, background]);
-  const eff = useMemo<LabValues>(() => ({
-    master,
-    emblem: emblem * master,
-    companion: companion * master,
-    trail: trail * master,
-    background: background * master
-  }), [master, emblem, companion, trail, background]);
-
-  // persistence with debounce
-  const persist = (key: string, val: number) => {
-    const t = setTimeout(() => localStorage.setItem(key, val.toString()), 150);
-    return () => clearTimeout(t);
-  };
-  useEffect(() => persist(STORAGE_KEYS.master, master), [master]);
-  useEffect(() => persist(STORAGE_KEYS.emblem, emblem), [emblem]);
-  useEffect(() => persist(STORAGE_KEYS.companion, companion), [companion]);
-  useEffect(() => persist(STORAGE_KEYS.trail, trail), [trail]);
-  useEffect(() => persist(STORAGE_KEYS.background, background), [background]);
-
-  const handleTab = (k: TabKey) => {
-    setActive(k);
-    cardRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
-  };
-
   const reset = () => {
-    (Object.values(STORAGE_KEYS)).forEach(k => localStorage.removeItem(k));
-    setMaster(0.5); setEmblem(0.5); setCompanion(0.5); setTrail(0.5); setBackground(0.5);
+    ['lab:master','lab:emblem','lab:companion','lab:trail','lab:background'].forEach(k=>localStorage.removeItem(k));
+    setMaster(0.6); setEmblem(0.7); setCompanion(0.5); setTrail(0.6); setBackground(0.4);
   };
 
-  const slider = (label: string, value: number, set: (n: number) => void, effVal: number) => (
+  const eff = {
+    master,
+    emblem: master * emblem,
+    companion: master * companion,
+    trail: master * trail,
+    background: master * background,
+  };
+
+  const slider = (label: string, value: number, setter: (n:number)=>void, effVal: number) => (
     <div className="lab-row">
       <label>{label}: {value.toFixed(2)}</label>
-      <input type="range" min={0} max={1} step={0.01} value={value} onChange={e => set(num(e))} />
+      <input type="range" min={0} max={1} step={0.01} value={value} onChange={e=>setter(num(e))} />
       <small>Effective: {effVal.toFixed(2)}</small>
     </div>
   );
 
   return (
-    <LabContext.Provider value={{ base, eff }}>
-      <div className="lab-page">
-        <div className="lab-layout">
-          <section className="lab-preview">
-            <h2>WebGL Preview ({active} layer active)</h2>
+    <div className="lab-page">
+      <div className="lab-layout">
+        <section className="lab-preview">
+          <canvas ref={canvasRef} className="shader-canvas" style={{ width: '100%', height: '260px' }} />
+          <div className="lab-values">
+            <strong>Effective Values</strong>
             <div>Master: {eff.master.toFixed(2)}</div>
             <div>Emblem: {eff.emblem.toFixed(2)}</div>
             <div>Companion: {eff.companion.toFixed(2)}</div>
             <div>Trail: {eff.trail.toFixed(2)}</div>
             <div>Background: {eff.background.toFixed(2)}</div>
-          </section>
-          <div ref={cardRef} className="lab-card">
-            {slider('Master', master, setMaster, eff.master)}
-            <Tabs active={active} onChange={handleTab} />
-            {active === 'emblem' && slider('Emblem', emblem, setEmblem, eff.emblem)}
-            {active === 'companion' && slider('Companion', companion, setCompanion, eff.companion)}
-            {active === 'trail' && slider('Trail', trail, setTrail, eff.trail)}
-            {active === 'background' && slider('Background', background, setBackground, eff.background)}
-            <div className="lab-footer"><button className="lab-reset" onClick={reset}>Reset All</button></div>
           </div>
+        </section>
+        <div className="lab-card">
+          {slider('Master', master, setMaster, eff.master)}
+          <Tabs active={active} onChange={setActive} />
+          {active === 'emblem' && slider('Emblem', emblem, setEmblem, eff.emblem)}
+          {active === 'companion' && slider('Companion', companion, setCompanion, eff.companion)}
+          {active === 'trail' && slider('Trail', trail, setTrail, eff.trail)}
+          {active === 'background' && slider('Background', background, setBackground, eff.background)}
+          <div className="lab-footer"><button className="lab-reset" onClick={reset}>Reset All</button></div>
         </div>
       </div>
-    </LabContext.Provider>
+    </div>
   );
 }

--- a/src/webgl/labEngine.ts
+++ b/src/webgl/labEngine.ts
@@ -50,19 +50,21 @@ export function createLabEngine(canvas: HTMLCanvasElement, uniformsRef: React.Mu
     ]),
     gl.STATIC_DRAW
   );
-  const loc = gl.getAttribLocation(prog, 'position');
-  gl.enableVertexAttribArray(loc);
-  gl.vertexAttribPointer(loc, 2, gl.FLOAT, false, 0, 0);
+  const posLoc = gl.getAttribLocation(prog, 'position');
+  gl.enableVertexAttribArray(posLoc);
+  gl.vertexAttribPointer(posLoc, 2, gl.FLOAT, false, 0, 0);
 
-  const uTime = gl.getUniformLocation(prog, 'uTime');
-  const uResolution = gl.getUniformLocation(prog, 'uResolution');
-  const uMaster = gl.getUniformLocation(prog, 'uMaster');
-  const uEmblem = gl.getUniformLocation(prog, 'uEmblem');
-  const uCompanion = gl.getUniformLocation(prog, 'uCompanion');
-  const uTrail = gl.getUniformLocation(prog, 'uTrail');
-  const uBackground = gl.getUniformLocation(prog, 'uBackground');
-  const uThemeA = gl.getUniformLocation(prog, 'uThemeA');
-  const uThemeB = gl.getUniformLocation(prog, 'uThemeB');
+  const loc = {
+    uTime: gl.getUniformLocation(prog, 'uTime'),
+    uResolution: gl.getUniformLocation(prog, 'uResolution'),
+    uMaster: gl.getUniformLocation(prog, 'uMaster'),
+    uEmblem: gl.getUniformLocation(prog, 'uEmblem'),
+    uCompanion: gl.getUniformLocation(prog, 'uCompanion'),
+    uTrail: gl.getUniformLocation(prog, 'uTrail'),
+    uBackground: gl.getUniformLocation(prog, 'uBackground'),
+    uThemeA: gl.getUniformLocation(prog, 'uThemeA'),
+    uThemeB: gl.getUniformLocation(prog, 'uThemeB'),
+  } as const;
 
   const fit = () => {
     const dpr = Math.min(2, window.devicePixelRatio || 1);
@@ -79,16 +81,16 @@ export function createLabEngine(canvas: HTMLCanvasElement, uniformsRef: React.Mu
   const frame = () => {
     raf = requestAnimationFrame(frame);
     const t = (performance.now() - start) / 1000;
-    gl.uniform1f(uTime, t);
-    gl.uniform2f(uResolution, canvas.width, canvas.height);
+    gl.uniform1f(loc.uTime, t);
+    gl.uniform2f(loc.uResolution, canvas.width, canvas.height);
     const u = uniformsRef.current;
-    gl.uniform1f(uMaster, u.master);
-    gl.uniform1f(uEmblem, u.emblem);
-    gl.uniform1f(uCompanion, u.companion);
-    gl.uniform1f(uTrail, u.trail);
-    gl.uniform1f(uBackground, u.background);
-    gl.uniform3fv(uThemeA, u.themeA);
-    gl.uniform3fv(uThemeB, u.themeB);
+    gl.uniform1f(loc.uMaster, u.master);
+    gl.uniform1f(loc.uEmblem, u.master * u.emblem);
+    gl.uniform1f(loc.uCompanion, u.master * u.companion);
+    gl.uniform1f(loc.uTrail, u.master * u.trail);
+    gl.uniform1f(loc.uBackground, u.master * u.background);
+    gl.uniform3fv(loc.uThemeA, u.themeA);
+    gl.uniform3fv(loc.uThemeB, u.themeB);
     gl.drawArrays(gl.TRIANGLES, 0, 3);
   };
   frame();


### PR DESCRIPTION
## Summary
- hook lab sliders up to WebGL via a persistent engine
- debounce slider persistence and sync uniforms through a ref
- compute master-weighted uniform values in render loop

## Testing
- `npm test` (fails: Missing script: "test")
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68afae3646fc832d988844ebb5a7ffbd