### PR TITLE
feat: add lab options drawer and improve lab canvas

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -20,7 +20,7 @@ body {
   border: 2px solid #222;
   padding: 16px;
 }
-.shader-canvas { display:block; width:100%; height:auto; }
+.shader-canvas { display:block; width:100%; height:auto; border-radius:16px; }
 
 
 .app-root {
@@ -223,3 +223,6 @@ html, body, #root, .page { background: transparent; }
 .lab-row input[type="range"] { width:100%; touch-action:none; }
 .lab-footer { margin-top: 12px; display:flex; justify-content:flex-end; }
 .lab-reset { background:#fff; border:1px solid #cfd4dc; border-radius:10px; padding:10px 14px; font-weight:700; }
+.lab-options { margin-top:12px; }
+.lab-options-toggle { width:100%; text-align:left; background:#fff; border:1px solid #cfd4dc; border-radius:10px; padding:8px 12px; font-weight:600; cursor:pointer; }
+.lab-options-body { margin-top:12px; }

--- a/src/lab/LabTool.tsx
+++ b/src/lab/LabTool.tsx
@@ -5,20 +5,29 @@ import '../index.css';
 
 const ls = (k: string, fallback: number) => Number(localStorage.getItem(k) ?? fallback);
 
+type Theme = 'planet' | 'neon' | 'minimal';
+const THEME_COLORS: Record<Theme, { A: [number, number, number]; B: [number, number, number] }> = {
+  planet: { A: [0.2, 0.6, 1.0], B: [0.0, 0.0, 0.0] },
+  neon: { A: [1.0, 0.3, 0.7], B: [0.0, 0.0, 0.0] },
+  minimal: { A: [1.0, 1.0, 1.0], B: [0.0, 0.0, 0.0] },
+};
+
 export default function LabTool() {
   const [master, setMaster] = useState(ls('lab:master', 0.6));
   const [emblem, setEmblem] = useState(ls('lab:emblem', 0.7));
   const [companion, setCompanion] = useState(ls('lab:companion', 0.5));
   const [trail, setTrail] = useState(ls('lab:trail', 0.6));
   const [background, setBackground] = useState(ls('lab:background', 0.4));
+  const [theme, setTheme] = useState<Theme>((localStorage.getItem('lab:theme') as Theme) || 'planet');
+  const [optionsOpen, setOptionsOpen] = useState(localStorage.getItem('lab:optionsOpen') === 'true');
   const uniformsRef = useRef<Uniforms>({
     master,
     emblem,
     companion,
     trail,
     background,
-    themeA: [0.2, 0.6, 1.0],
-    themeB: [0.0, 0.0, 0.0],
+    themeA: THEME_COLORS[theme].A,
+    themeB: THEME_COLORS[theme].B,
   });
   const canvasRef = useRef<HTMLCanvasElement | null>(null);
 
@@ -27,6 +36,8 @@ export default function LabTool() {
   useEffect(() => { const t=setTimeout(()=>localStorage.setItem('lab:companion', String(companion)),150); return()=>clearTimeout(t); }, [companion]);
   useEffect(() => { const t=setTimeout(()=>localStorage.setItem('lab:trail', String(trail)),150); return()=>clearTimeout(t); }, [trail]);
   useEffect(() => { const t=setTimeout(()=>localStorage.setItem('lab:background', String(background)),150); return()=>clearTimeout(t); }, [background]);
+  useEffect(() => { const t=setTimeout(()=>localStorage.setItem('lab:theme', theme),150); return()=>clearTimeout(t); }, [theme]);
+  useEffect(() => { localStorage.setItem('lab:optionsOpen', String(optionsOpen)); }, [optionsOpen]);
 
   useEffect(() => {
     uniformsRef.current.master = master;
@@ -34,7 +45,10 @@ export default function LabTool() {
     uniformsRef.current.companion = companion;
     uniformsRef.current.trail = trail;
     uniformsRef.current.background = background;
-  }, [master, emblem, companion, trail, background]);
+    const { A, B } = THEME_COLORS[theme];
+    uniformsRef.current.themeA = A;
+    uniformsRef.current.themeB = B;
+  }, [master, emblem, companion, trail, background, theme]);
 
   useEffect(() => {
     const canvas = canvasRef.current;
@@ -47,8 +61,8 @@ export default function LabTool() {
   const num = (e: React.ChangeEvent<HTMLInputElement>) => e.currentTarget.valueAsNumber;
 
   const reset = () => {
-    ['lab:master','lab:emblem','lab:companion','lab:trail','lab:background'].forEach(k=>localStorage.removeItem(k));
-    setMaster(0.6); setEmblem(0.7); setCompanion(0.5); setTrail(0.6); setBackground(0.4);
+    ['lab:master','lab:emblem','lab:companion','lab:trail','lab:background','lab:theme'].forEach(k=>localStorage.removeItem(k));
+    setMaster(0.6); setEmblem(0.7); setCompanion(0.5); setTrail(0.6); setBackground(0.4); setTheme('planet');
   };
 
   const eff = {
@@ -59,11 +73,12 @@ export default function LabTool() {
     background: master * background,
   };
 
-  const slider = (label: string, value: number, setter: (n:number)=>void, effVal: number) => (
+  const slider = (label: string, value: number, setter: (n:number)=>void, effVal: number, help?: string) => (
     <div className="lab-row">
       <label>{label}: {value.toFixed(2)}</label>
       <input type="range" min={0} max={1} step={0.01} value={value} onChange={e=>setter(num(e))} />
       <small>Effective: {effVal.toFixed(2)}</small>
+      {help && <small>{help}</small>}
     </div>
   );
 
@@ -71,24 +86,39 @@ export default function LabTool() {
     <div className="lab-page">
       <div className="lab-layout">
         <section className="lab-preview">
-          <canvas ref={canvasRef} className="shader-canvas" style={{ width: '100%', height: '260px' }} />
-          <div className="lab-values">
-            <strong>Effective Values</strong>
-            <div>Master: {eff.master.toFixed(2)}</div>
-            <div>Emblem: {eff.emblem.toFixed(2)}</div>
-            <div>Companion: {eff.companion.toFixed(2)}</div>
-            <div>Trail: {eff.trail.toFixed(2)}</div>
-            <div>Background: {eff.background.toFixed(2)}</div>
-          </div>
+          <h2 className="lab-title">Shader Lab</h2>
+          <canvas id="labCanvas" ref={canvasRef} className="shader-canvas" />
         </section>
         <div className="lab-card">
-          {slider('Master', master, setMaster, eff.master)}
           <Tabs active={active} onChange={setActive} />
           {active === 'emblem' && slider('Emblem', emblem, setEmblem, eff.emblem)}
           {active === 'companion' && slider('Companion', companion, setCompanion, eff.companion)}
           {active === 'trail' && slider('Trail', trail, setTrail, eff.trail)}
           {active === 'background' && slider('Background', background, setBackground, eff.background)}
           <div className="lab-footer"><button className="lab-reset" onClick={reset}>Reset All</button></div>
+          <div className="lab-options">
+            <button className="lab-options-toggle" onClick={() => setOptionsOpen(o=>!o)}>⚙️ Lab Options</button>
+            {optionsOpen && (
+              <div className="lab-options-body">
+                <div className="lab-row">
+                  <label>Lab Themes</label>
+                  <div className="lab-themes lab-tabs">
+                    {(['planet','neon','minimal'] as Theme[]).map(t => (
+                      <button
+                        key={t}
+                        className={`lab-tab ${theme===t ? 'is-active' : ''}`}
+                        onClick={() => setTheme(t)}
+                        type="button"
+                      >
+                        {t[0].toUpperCase() + t.slice(1)}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+                {slider('Master (global influence)', master, setMaster, eff.master, 'Scales all other sliders.')}
+              </div>
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/src/webgl/labEngine.ts
+++ b/src/webgl/labEngine.ts
@@ -68,9 +68,10 @@ export function createLabEngine(canvas: HTMLCanvasElement, uniformsRef: React.Mu
 
   const fit = () => {
     const dpr = Math.min(2, window.devicePixelRatio || 1);
-    const rect = canvas.getBoundingClientRect();
-    canvas.width = rect.width * dpr;
-    canvas.height = rect.height * dpr;
+    const w = canvas.clientWidth;
+    const h = canvas.clientHeight;
+    canvas.width = w * dpr;
+    canvas.height = h * dpr;
     gl.viewport(0, 0, canvas.width, canvas.height);
   };
   fit();


### PR DESCRIPTION
## Summary
- add collapsible Lab Options drawer with theme selection and master slider
- wire WebGL lab canvas with proper DPR resize and id `labCanvas`
- style canvas and options, persist drawer state

## Testing
- `npm test` (fails: Missing script "test")
- `npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68afb42e7064832da3923853d43970a7