### PR TITLE
feat: add shader lab presets and glass panel

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -318,3 +318,22 @@ html, body, #root, .page { background: transparent; }
   .dock-tabs{ gap:8px; }
 }
 
+.lab-page{min-height:100vh;padding:16px;}
+.preview-card{border-radius:24px;background:rgba(10,12,18,.85);box-shadow:0 18px 60px rgba(0,0,0,.45),0 1px 0 rgba(255,255,255,.05) inset;overflow:hidden;}
+.preview-inner{padding:20px;}
+.canvas-mount{height:clamp(320px,52vw,520px);border-radius:20px;background:radial-gradient(120% 120% at 50% 40%,#3b2c57 0%,#151826 70%);box-shadow:0 20px 50px rgba(0,0,0,.35),0 0 1px rgba(255,255,255,.12) inset;position:relative;}
+.glass-panel{position:relative;border-radius:22px;padding:16px;background:linear-gradient(to bottom right,rgba(255,255,255,.08),rgba(255,255,255,.03));backdrop-filter:blur(10px) saturate(130%);-webkit-backdrop-filter:blur(10px) saturate(130%);box-shadow:0 18px 60px rgba(0,0,0,.35),0 0 0 1px rgba(255,255,255,.06) inset;}
+.glass-panel::after{content:"";position:absolute;inset:0;border-radius:22px;pointer-events:none;box-shadow:0 1px 16px rgba(255,255,255,.08) inset;}
+.panel-head{display:flex;justify-content:space-between;align-items:center;margin-bottom:8px;}
+.chips{display:flex;gap:8px;flex-wrap:wrap;}
+.chip{padding:8px 12px;border-radius:999px;background:rgba(255,255,255,.06);border:1px solid rgba(255,255,255,.08);color:#e9ecff;font-weight:600;}
+.chip.is-active{background:rgba(98,132,255,.22);border-color:rgba(98,132,255,.45);box-shadow:0 0 0 3px rgba(98,132,255,.18) inset;}
+.control{display:grid;gap:6px;margin:12px 0;}
+.control label{font-weight:600;color:#e8eaf6;}
+.control input[type=range]{width:100%;touch-action:none;}
+.grid.two{display:grid;grid-template-columns:1fr;gap:12px;}
+@media (min-width:680px){.grid.two{grid-template-columns:1fr 1fr;}}
+.panel-foot form{display:flex;gap:8px;flex-wrap:wrap;margin-top:8px;}
+.panel-foot input{flex:1 1 220px;border-radius:12px;padding:10px 12px;border:1px solid rgba(255,255,255,.12);background:rgba(255,255,255,.06);color:#fff;}
+.panel-foot button{border-radius:12px;padding:10px 14px;font-weight:700;color:#0c1220;background:linear-gradient(180deg,#6fd3ff,#57b0ff);border:1px solid rgba(255,255,255,.18);}
+.panel-foot button:nth-child(3){background:linear-gradient(180deg,#b0ffa6,#74e38d);}

--- a/src/lib/presets.ts
+++ b/src/lib/presets.ts
@@ -1,0 +1,13 @@
+export type LabPresetKey = "planet" | "neon" | "minimal";
+export type LabState = {
+  master: number;
+  emblem: { hue: number; gloss: number; roughness: number; rim: number };
+  companion: { amount: number };
+  trail: { amount: number };
+  background: { vignette: number; hueShift?: number };
+};
+export const LAB_PRESETS: Record<LabPresetKey, LabState> = {
+  planet:  { master:1.0, emblem:{ hue:0.62, gloss:0.55, roughness:0.35, rim:0.5 }, companion:{amount:0.5}, trail:{amount:0.6}, background:{vignette:0.25, hueShift:0.0} },
+  neon:    { master:0.9, emblem:{ hue:0.82, gloss:0.8,  roughness:0.15, rim:0.65}, companion:{amount:0.35},trail:{amount:0.9}, background:{vignette:0.18, hueShift:0.15}},
+  minimal: { master:0.7, emblem:{ hue:0.05, gloss:0.25, roughness:0.6,  rim:0.35}, companion:{amount:0.2}, trail:{amount:0.1}, background:{vignette:0.12, hueShift:-0.08}}
+};

--- a/src/routes/lab/LabTool.tsx
+++ b/src/routes/lab/LabTool.tsx
@@ -1,43 +1,44 @@
-/*
-  - Wrap page with .lab-page grid
-  - Keep canvas in #labLiveView with <canvas className="lab-canvas" />
-  - Controls panel uses .dock with .dock-header/.dock-body and .dock-tabs
-  - IMPORTANT: do not re-init GL on slider changes; uniforms from controlsRef drive shader.
-*/
-import React, { useEffect, useRef, useState } from "react";
-import "./LabLayout.css";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { LAB_PRESETS, type LabPresetKey, type LabState } from "../../lib/presets";
 
-type TabKey = "emblem" | "companion" | "trail" | "background" | "skins";
+export default function Lab() {
+  const glRef = useRef<{ setState: (s: LabState) => void } | null>(null);
+  const mountRef = useRef<HTMLDivElement | null>(null);
 
-export default function LabTool() {
-  const canvasRef = useRef<HTMLCanvasElement | null>(null);
-  const controlsRef = useRef({
-    hue: 0.33, gloss: 0.5, rough: 0.4, rim: 0.5,
-    companion: 0.5, trail: 0.5, bg: 0.3
-  });
-  const [tab, setTab] = useState<TabKey>("emblem");
-  const tabTitle = `${tab[0].toUpperCase() + tab.slice(1)} Controls`;
+  const initial = useMemo<LabState>(() => LAB_PRESETS.planet, []);
+  const [presetKey, setPresetKey] = useState<LabPresetKey>("planet");
+  const [state, setState] = useState<LabState>(initial);
 
-  // ---- GL init once -------------------------------------------------
+  // Mount GL exactly once; expose setState to update uniforms only
   useEffect(() => {
-    const canvas = canvasRef.current!;
-    // initGL is your existing helper – create program with emblem.vert/frag
-    // It must return { gl, program, setUniform(name, value), dispose() }
+    if (!mountRef.current || glRef.current) return;
+    const canvas = document.createElement("canvas");
+    canvas.style.width = "100%";
+    canvas.style.height = "100%";
+    mountRef.current.appendChild(canvas);
+
     const glHandle = (window as any).__initLabGL?.(canvas, {
       vertexUrl: "/shaders/lab/emblem.vert",
-      fragmentUrl: "/shaders/lab/emblem.frag"
+      fragmentUrl: "/shaders/lab/emblem.frag",
     });
+
+    glRef.current = {
+      setState: (s: LabState) => {
+        glHandle?.setUniform?.("uHue", s.emblem.hue);
+        glHandle?.setUniform?.("uGloss", s.emblem.gloss);
+        glHandle?.setUniform?.("uRoughness", s.emblem.roughness);
+        glHandle?.setUniform?.("uRim", s.emblem.rim);
+        glHandle?.setUniform?.("uCompanion", s.companion.amount);
+        glHandle?.setUniform?.("uTrail", s.trail.amount);
+        glHandle?.setUniform?.("uBgVignette", s.background.vignette);
+        glHandle?.setUniform?.("uHueShift", s.background.hueShift ?? 0);
+        glHandle?.setUniform?.("uMaster", s.master);
+      },
+    };
+    glRef.current.setState(initial);
 
     let raf = 0;
     const loop = (t: number) => {
-      const u = controlsRef.current;
-      glHandle?.setUniform?.("uHue", u.hue);
-      glHandle?.setUniform?.("uGloss", u.gloss);
-      glHandle?.setUniform?.("uRough", u.rough);
-      glHandle?.setUniform?.("uRim", u.rim);
-      glHandle?.setUniform?.("uCompanion", u.companion);
-      glHandle?.setUniform?.("uTrail", u.trail);
-      glHandle?.setUniform?.("uBackground", u.bg);
       glHandle?.setUniform?.("uTime", t * 0.001);
       glHandle?.render?.();
       raf = requestAnimationFrame(loop);
@@ -46,105 +47,204 @@ export default function LabTool() {
 
     const onResize = () => {
       const dpr = Math.min(2, window.devicePixelRatio || 1);
-      const rect = canvas.getBoundingClientRect();
+      const rect = mountRef.current!.getBoundingClientRect();
       const w = Math.round(rect.width * dpr);
       const h = Math.round(rect.height * dpr);
       if (canvas.width !== w || canvas.height !== h) {
-        canvas.width = w; canvas.height = h;
+        canvas.width = w;
+        canvas.height = h;
         glHandle?.resize?.(w, h, dpr);
       }
     };
     onResize();
-    const ro = new ResizeObserver(onResize); ro.observe(canvas);
+    const ro = new ResizeObserver(onResize);
+    ro.observe(mountRef.current!);
 
-    return () => { cancelAnimationFrame(raf); ro.disconnect(); glHandle?.dispose?.(); };
-  }, []);
+    return () => {
+      cancelAnimationFrame(raf);
+      ro.disconnect();
+      glHandle?.dispose?.();
+      glRef.current = null;
+      mountRef.current?.removeChild(canvas);
+    };
+  }, [initial]);
 
-  // helper to bind sliders
-  const bind = <K extends keyof typeof controlsRef.current>(key: K) => ({
-    value: controlsRef.current[key] as number,
-    onChange: (e: React.ChangeEvent<HTMLInputElement>) => {
-      (controlsRef.current as any)[key] = (e.target as HTMLInputElement).valueAsNumber;
-    }
-  });
+  // push changes to uniforms (no recompile)
+  useEffect(() => {
+    glRef.current?.setState(state);
+  }, [state]);
+
+  const applyPreset = (k: LabPresetKey) => {
+    setPresetKey(k);
+    setState(LAB_PRESETS[k]);
+  };
+
+  const saveSkin = (name: string) => {
+    const key = "lab:skins";
+    const list = JSON.parse(localStorage.getItem(key) || "[]");
+    list.unshift({ name, presetKey, state, savedAt: Date.now() });
+    localStorage.setItem(key, JSON.stringify(list));
+  };
 
   return (
     <div className="lab-page">
-      <div className="lab-header">{/* (keep your Home/Lab buttons) */}</div>
-
-      <div id="labLiveView" className="lab-preview">
-        <canvas ref={canvasRef} className="lab-canvas" />
-      </div>
-
-      <div className="dock" role="region" aria-label="Lab Controls">
-        <div className="dock-header">
-          <div className="dock-title">{tabTitle}</div>
+      <section className="preview-card">
+        <div className="preview-inner">
+          <div className="canvas-mount" ref={mountRef} />
         </div>
-        <div className="dock-body">
-          {tab === "emblem" && (
-            <>
-              <div className="dock-row">
-                <label className="dock-label">Hue</label>
-                <input type="range" min={0} max={1} step={0.01} {...bind("hue")} />
-              </div>
-              <div className="dock-row">
-                <label className="dock-label">Gloss</label>
-                <input type="range" min={0} max={1} step={0.01} {...bind("gloss")} />
-              </div>
-              <div className="dock-row">
-                <label className="dock-label">Roughness</label>
-                <input type="range" min={0} max={1} step={0.01} {...bind("rough")} />
-              </div>
-              <div className="dock-row">
-                <label className="dock-label">Rim Strength</label>
-                <input type="range" min={0} max={1} step={0.01} {...bind("rim")} />
-              </div>
-            </>
-          )}
+      </section>
 
-          {tab === "companion" && (
-            <div className="dock-row">
-              <label className="dock-label">Companion</label>
-              <input type="range" min={0} max={1} step={0.01} {...bind("companion")} />
-            </div>
-          )}
+      <section className="glass-panel">
+        <header className="panel-head">
+          <div className="chips">
+            <button
+              className={`chip ${presetKey === "planet" ? "is-active" : ""}`}
+              onClick={() => applyPreset("planet")}
+            >
+              Planet
+            </button>
+            <button
+              className={`chip ${presetKey === "neon" ? "is-active" : ""}`}
+              onClick={() => applyPreset("neon")}
+            >
+              Neon
+            </button>
+            <button
+              className={`chip ${presetKey === "minimal" ? "is-active" : ""}`}
+              onClick={() => applyPreset("minimal")}
+            >
+              Minimal
+            </button>
+          </div>
+        </header>
 
-          {tab === "trail" && (
-            <div className="dock-row">
-              <label className="dock-label">Trail</label>
-              <input type="range" min={0} max={1} step={0.01} {...bind("trail")} />
-            </div>
-          )}
+        <div className="control">
+          <label>Master: {state.master.toFixed(2)}</label>
+          <input
+            type="range"
+            min={0}
+            max={1}
+            step={0.01}
+            value={state.master}
+            onChange={(e) =>
+              setState((s) => ({
+                ...s,
+                master: (e.currentTarget as HTMLInputElement).valueAsNumber,
+              }))
+            }
+          />
+        </div>
 
-          {tab === "background" && (
-            <div className="dock-row">
-              <label className="dock-label">Background</label>
-              <input type="range" min={0} max={1} step={0.01} {...bind("bg")} />
-            </div>
-          )}
-
-          {tab === "skins" && (
-            <div className="dock-row">
-              <label className="dock-label">Skins</label>
-              {/* keep your export UI */}
-            </div>
-          )}
-
-          <div className="dock-tabs" role="tablist" aria-label="Lab sections">
-            {(["emblem","companion","trail","background","skins"] as TabKey[]).map(k => (
-              <button
-                key={k}
-                className="dock-tab"
-                role="tab"
-                aria-selected={tab===k}
-                onClick={()=>setTab(k)}
-              >
-                {k[0].toUpperCase()+k.slice(1)}
-              </button>
-            ))}
+        <div className="grid two">
+          <div className="control">
+            <label>Hue: {(state.emblem.hue * 360) | 0}°</label>
+            <input
+              type="range"
+              min={0}
+              max={1}
+              step={0.001}
+              value={state.emblem.hue}
+              onChange={(e) =>
+                setState((s) => ({
+                  ...s,
+                  emblem: {
+                    ...s.emblem,
+                    hue: (e.currentTarget as HTMLInputElement).valueAsNumber,
+                  },
+                }))
+              }
+            />
+          </div>
+          <div className="control">
+            <label>Gloss: {state.emblem.gloss.toFixed(2)}</label>
+            <input
+              type="range"
+              min={0}
+              max={1}
+              step={0.01}
+              value={state.emblem.gloss}
+              onChange={(e) =>
+                setState((s) => ({
+                  ...s,
+                  emblem: {
+                    ...s.emblem,
+                    gloss: (e.currentTarget as HTMLInputElement).valueAsNumber,
+                  },
+                }))
+              }
+            />
+          </div>
+          <div className="control">
+            <label>Roughness: {state.emblem.roughness.toFixed(2)}</label>
+            <input
+              type="range"
+              min={0}
+              max={1}
+              step={0.01}
+              value={state.emblem.roughness}
+              onChange={(e) =>
+                setState((s) => ({
+                  ...s,
+                  emblem: {
+                    ...s.emblem,
+                    roughness: (e.currentTarget as HTMLInputElement).valueAsNumber,
+                  },
+                }))
+              }
+            />
+          </div>
+          <div className="control">
+            <label>Rim: {state.emblem.rim.toFixed(2)}</label>
+            <input
+              type="range"
+              min={0}
+              max={1}
+              step={0.01}
+              value={state.emblem.rim}
+              onChange={(e) =>
+                setState((s) => ({
+                  ...s,
+                  emblem: {
+                    ...s.emblem,
+                    rim: (e.currentTarget as HTMLInputElement).valueAsNumber,
+                  },
+                }))
+              }
+            />
           </div>
         </div>
-      </div>
+
+        <footer className="panel-foot">
+          <form
+            onSubmit={(e) => {
+              e.preventDefault();
+              const i = e.currentTarget.elements.namedItem("skinName") as HTMLInputElement;
+              if (i.value.trim()) {
+                saveSkin(i.value.trim());
+                i.value = "";
+              }
+            }}
+          >
+            <input name="skinName" placeholder="Skin name…" />
+            <button type="submit">Save Skin</button>
+            <button
+              type="button"
+              onClick={() => {
+                const json = JSON.stringify({ presetKey, state }, null, 2);
+                const blob = new Blob([json], { type: "application/json" });
+                const url = URL.createObjectURL(blob);
+                const a = document.createElement("a");
+                a.href = url;
+                a.download = `skin-${Date.now()}.json`;
+                a.click();
+                URL.revokeObjectURL(url);
+              }}
+            >
+              Export JSON
+            </button>
+          </form>
+        </footer>
+      </section>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- add preset definitions for Planet, Neon and Minimal
- update lab route with single-run WebGL mount and preset controls
- style lab page with floating glass panel and chips

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Missing script "build")

------
https://chatgpt.com/codex/tasks/task_e_68b0c9c33298832d9b41c80838cef9fe