### PR TITLE
refactor: modernize lab dock

### DIFF
--- a/src/styles/lab.css
+++ b/src/styles/lab.css
@@ -1,0 +1,27 @@
+.dock {
+  position: fixed; left: 0; right: 0; bottom: 0; z-index: 10;
+  padding: 10px 12px calc(10px + env(safe-area-inset-bottom));
+  pointer-events: none; /* so gaps don’t block the canvas */
+}
+.dock-card {
+  pointer-events: all;
+  max-width: 1100px; margin: 0 auto;
+  height: 220px; border-radius: 16px;
+  padding: 12px 14px;
+  background: linear-gradient(180deg, rgba(18,18,22,.42), rgba(18,18,22,.58));
+  border: 1px solid rgba(255,255,255,.08);
+  box-shadow: 0 18px 40px rgba(0,0,0,.45), inset 0 1px 0 rgba(255,255,255,.06);
+  backdrop-filter: blur(14px) saturate(125%);
+  display: grid; grid-template-rows: auto 1fr; gap: 8px;
+}
+.tabs { display:flex; gap:10px; justify-content:center; }
+.tab {
+  padding: 8px 14px; border-radius: 12px; font-weight: 700;
+  background: rgba(255,255,255,.06); border: 1px solid rgba(255,255,255,.08);
+}
+.tab.is-active { background: rgba(120,160,255,.20); box-shadow: 0 0 0 2px rgba(120,160,255,.35) inset; }
+.sliders { display:grid; grid-template-columns: 1fr 1fr; gap: 10px 16px; align-content:start; }
+.field { display:grid; gap:6px; }
+.field .row { display:flex; justify-content:space-between; gap:12px; font-weight:600; }
+.field .row .value { opacity:.9; font-variant-numeric: tabular-nums; }
+input[type="range"] { width:100%; touch-action:none; }


### PR DESCRIPTION
## Summary
- style lab dock as fixed glass overlay
- rewrite lab panel markup with tabs and numeric sliders
- wire sliders with valueAsNumber and persist uniforms

## Testing
- `npm test` (fails: Missing script: "test")
- `npx tsc -p tsconfig.json --noEmit` (fails: 'gl' is possibly 'null')

------
https://chatgpt.com/codex/tasks/task_e_68b0f398a628832da049eac3f1d91c92