### PR TITLE
Fix lab rendering and live controls

### DIFF
--- a/src/lab/backgroundPresets.ts
+++ b/src/lab/backgroundPresets.ts
@@ -1,0 +1,8 @@
+export const activePreset = {
+  a: [0.2, 0.3, 0.7],
+  b: [0.0, 0.0, 0.1],
+  vignette: 0.3,
+  noise: 0.15,
+  speed: 1.0,
+  intensity: 0.9,
+};

--- a/src/lab/backgroundRenderer.ts
+++ b/src/lab/backgroundRenderer.ts
@@ -1,0 +1,144 @@
+import { activePreset } from './backgroundPresets';
+import { sizeCanvasToDisplay } from './canvas';
+
+let gl: WebGLRenderingContext | null = null;
+let program: WebGLProgram | null = null;
+let quadBuffer: WebGLBuffer | null = null;
+let canvasRef: HTMLCanvasElement | null = null;
+
+function createShader(gl: WebGLRenderingContext, type: number, source: string): WebGLShader {
+  const sh = gl.createShader(type)!;
+  gl.shaderSource(sh, source);
+  gl.compileShader(sh);
+  if (!gl.getShaderParameter(sh, gl.COMPILE_STATUS)) {
+    throw new Error(String(gl.getShaderInfoLog(sh)));
+  }
+  return sh;
+}
+
+function createProgram(gl: WebGLRenderingContext, vs: string, fs: string) {
+  const prog = gl.createProgram()!;
+  const v = createShader(gl, gl.VERTEX_SHADER, vs);
+  const f = createShader(gl, gl.FRAGMENT_SHADER, fs);
+  gl.attachShader(prog, v);
+  gl.attachShader(prog, f);
+  gl.linkProgram(prog);
+  if (!gl.getProgramParameter(prog, gl.LINK_STATUS)) {
+    throw new Error(String(gl.getProgramInfoLog(prog)));
+  }
+  return prog;
+}
+
+const vertexShader = `
+  attribute vec2 a_position;
+  varying vec2 vUv;
+  void main() {
+    vUv = a_position * 0.5 + 0.5;
+    gl_Position = vec4(a_position, 0.0, 1.0);
+  }
+`;
+
+const fragmentShader = `
+  precision mediump float;
+  uniform float uTime;
+  uniform vec3  uColorA;
+  uniform vec3  uColorB;
+  uniform float uVignette;
+  uniform float uNoise;
+  uniform float uSpeed;
+  uniform float uIntensity;
+  varying vec2 vUv;
+
+  float hash(vec2 p) { return fract(sin(dot(p, vec2(127.1,311.7))) * 43758.5453); }
+  float noise2(vec2 p){
+    vec2 i = floor(p), f = fract(p);
+    vec2 u = f*f*(3.0-2.0*f);
+    return mix(mix(hash(i+vec2(0,0)), hash(i+vec2(1,0)), u.x),
+               mix(hash(i+vec2(0,1)), hash(i+vec2(1,1)), u.x), u.y);
+  }
+
+  void main(){
+    vec2 uv = vUv;
+    float t = uTime * uSpeed;
+    float w1 = sin(uv.x*3.0 + t*0.5) * 0.3;
+    float w2 = sin(uv.y*4.0 + t*0.7) * 0.2;
+    float w3 = sin((uv.x+uv.y)*2.0 + t*0.3) * 0.4;
+    float patt = w1 + w2 + w3 + noise2(uv*3.0 + t*0.1)*uNoise;
+
+    vec3 col = mix(uColorB, uColorA, (patt+1.0)*0.5) * uIntensity;
+
+    float dist = distance(uv, vec2(0.5));
+    float vig  = 1.0 - smoothstep(0.3, 1.0, dist) * uVignette;
+    col *= vig;
+    col += exp(-dist*1.8) * 0.3 * uColorA;
+
+    gl_FragColor = vec4(col, 1.0);
+  }
+`;
+
+export function initBackgroundRenderer(canvas: HTMLCanvasElement) {
+  canvasRef = canvas;
+  gl = canvas.getContext('webgl', { antialias: true, premultipliedAlpha: false });
+  if (!gl) return;
+
+  gl.disable(gl.DEPTH_TEST);
+  gl.disable(gl.BLEND);
+  gl.clearColor(0,0,0,1);
+
+  quadBuffer = gl.createBuffer()!;
+  gl.bindBuffer(gl.ARRAY_BUFFER, quadBuffer);
+  gl.bufferData(gl.ARRAY_BUFFER, new Float32Array([-1,-1, 1,-1, -1,1, 1,1]), gl.STATIC_DRAW);
+
+  program = createProgram(gl, vertexShader, fragmentShader);
+  gl.useProgram(program);
+
+  const posLoc = gl.getAttribLocation(program, 'a_position');
+  gl.enableVertexAttribArray(posLoc);
+  gl.vertexAttribPointer(posLoc, 2, gl.FLOAT, false, 0, 0);
+
+  onResize();
+  window.addEventListener('resize', onResize, { passive: true });
+}
+
+function onResize(){
+  if (!gl || !canvasRef) return;
+  const { width, height } = sizeCanvasToDisplay(canvasRef);
+  gl.viewport(0,0,width,height);
+}
+
+export function renderBackground(timeMs: number) {
+  if (!gl || !program) return;
+
+  gl.useProgram(program);
+  gl.clear(gl.COLOR_BUFFER_BIT);
+
+  const uTime      = gl.getUniformLocation(program, 'uTime');
+  const uColorA    = gl.getUniformLocation(program, 'uColorA');
+  const uColorB    = gl.getUniformLocation(program, 'uColorB');
+  const uVignette  = gl.getUniformLocation(program, 'uVignette');
+  const uNoise     = gl.getUniformLocation(program, 'uNoise');
+  const uSpeed     = gl.getUniformLocation(program, 'uSpeed');
+  const uIntensity = gl.getUniformLocation(program, 'uIntensity');
+
+  const t = timeMs * 0.001;
+  const p = activePreset;
+
+  gl.uniform1f(uTime, t);
+  gl.uniform3f(uColorA, p.a[0], p.a[1], p.a[2]);
+  gl.uniform3f(uColorB, p.b[0], p.b[1], p.b[2]);
+  gl.uniform1f(uVignette, p.vignette);
+  gl.uniform1f(uNoise,    p.noise);
+  gl.uniform1f(uSpeed,    p.speed);
+  gl.uniform1f(uIntensity, p.intensity ?? 0.9);
+
+  const posLoc = gl.getAttribLocation(program, 'a_position');
+  gl.enableVertexAttribArray(posLoc);
+  gl.vertexAttribPointer(posLoc, 2, gl.FLOAT, false, 0, 0);
+
+  gl.drawArrays(gl.TRIANGLE_STRIP, 0, 4);
+}
+
+export function disposeBackgroundRenderer() {
+  window.removeEventListener('resize', onResize);
+  gl = null; program = null; quadBuffer = null; canvasRef = null;
+}

--- a/src/lab/canvas.ts
+++ b/src/lab/canvas.ts
@@ -1,0 +1,12 @@
+export function sizeCanvasToDisplay(canvas: HTMLCanvasElement) {
+  const dpr = Math.max(1, Math.min(window.devicePixelRatio || 1, 3));
+  const w = Math.floor(canvas.clientWidth  || window.innerWidth);
+  const h = Math.floor(canvas.clientHeight || window.innerHeight);
+  const pw = Math.floor(w * dpr);
+  const ph = Math.floor(h * dpr);
+  if (canvas.width !== pw || canvas.height !== ph) {
+    canvas.width  = pw;
+    canvas.height = ph;
+  }
+  return { dpr, width: pw, height: ph, cssWidth: w, cssHeight: h };
+}

--- a/src/lab/worldRenderer.ts
+++ b/src/lab/worldRenderer.ts
@@ -1,0 +1,44 @@
+import { sizeCanvasToDisplay } from './canvas';
+
+export const state = {
+  emblem: { radius: 0.26 },
+  companion: { orbitRadius: 0.45, size: 0.04 },
+};
+
+export function renderWorld(timeMs: number, canvas: HTMLCanvasElement, activeTab?: string) {
+  const ctx = canvas.getContext('2d');
+  if (!ctx) return;
+
+  const { width, height } = sizeCanvasToDisplay(canvas);
+  const cx = canvas.width * 0.5;
+  const cy = canvas.height * 0.5;
+  const minDim = Math.min(canvas.width, canvas.height);
+  const R = Math.max(0.18, Math.min(state.emblem.radius ?? 0.26, 0.33)) * minDim;
+
+  ctx.clearRect(0, 0, width, height);
+
+  // draw emblem centered
+  ctx.fillStyle = '#ffffff';
+  ctx.beginPath();
+  ctx.arc(cx, cy, R, 0, Math.PI * 2);
+  ctx.fill();
+
+  // companion orbit
+  const or = state.companion.orbitRadius * minDim;
+  const angle = timeMs * 0.001;
+  const x = cx + Math.cos(angle) * or;
+  const y = cy + Math.sin(angle) * or;
+
+  ctx.fillStyle = '#88aaff';
+  ctx.beginPath();
+  ctx.arc(x, y, state.companion.size * minDim, 0, Math.PI * 2);
+  ctx.fill();
+
+  // trail from emblem center
+  const trailAlpha = activeTab === 'Trail' ? 1 : 0.2;
+  ctx.strokeStyle = `rgba(255,255,255,${trailAlpha})`;
+  ctx.beginPath();
+  ctx.moveTo(cx, cy);
+  ctx.lineTo(x, y);
+  ctx.stroke();
+}

--- a/src/lib/gl/labRenderer.ts
+++ b/src/lib/gl/labRenderer.ts
@@ -16,7 +16,7 @@ export default function initLabRenderer(
   canvas: HTMLCanvasElement,
   uniforms: LabUniforms
 ) {
-  const gl = canvas.getContext("webgl2");
+  const gl = canvas.getContext("webgl2")!;
   if (!gl) {
     throw new Error("WebGL2 not supported");
   }

--- a/src/styles/lab.css
+++ b/src/styles/lab.css
@@ -1,9 +1,10 @@
-.dock {
+#ui-dock {
   position: fixed; left: 0; right: 0; bottom: 0; z-index: 10;
-  padding: 10px 12px calc(10px + env(safe-area-inset-bottom));
+  padding: 10px 12px;
+  padding-bottom: max(22px, env(safe-area-inset-bottom));
   pointer-events: none; /* so gaps don’t block the canvas */
 }
-.dock-card {
+#ui-dock .dock-card {
   pointer-events: all;
   max-width: 1100px; margin: 0 auto;
   height: 220px; border-radius: 16px;
@@ -15,11 +16,18 @@
   display: grid; grid-template-rows: auto 1fr; gap: 8px;
 }
 .tabs { display:flex; gap:10px; justify-content:center; }
-.tab {
-  padding: 8px 14px; border-radius: 12px; font-weight: 700;
-  background: rgba(255,255,255,.06); border: 1px solid rgba(255,255,255,.08);
+.tab, .chip {
+  color: #e9edff;
+  padding: 8px 14px;
+  border-radius: 12px;
+  font-weight: 700;
+  background: rgba(255,255,255,0.08);
+  border: 1px solid rgba(255,255,255,0.10);
 }
-.tab.is-active { background: rgba(120,160,255,.20); box-shadow: 0 0 0 2px rgba(120,160,255,.35) inset; }
+.tab.active, .chip.active {
+  background: rgba(160,180,255,0.16);
+  outline: 2px solid rgba(120,160,255,0.55);
+}
 .sliders { display:grid; grid-template-columns: 1fr 1fr; gap: 10px 16px; align-content:start; }
 .field { display:grid; gap:6px; }
 .field .row { display:flex; justify-content:space-between; gap:12px; font-weight:600; }


### PR DESCRIPTION
## Summary
- add canvas display sizing helper and new background shader
- center world objects with clamped radius and single background canvas
- update lab sliders to live input and restyle dock chips/tabs

## Testing
- `npx tsc --noEmit`
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b1c1138104832db89da546438e5a55